### PR TITLE
Setup behaviours and dialyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /deps
 erl_crash.dump
 *.ez
+.dialyzer.plt

--- a/README.md
+++ b/README.md
@@ -18,3 +18,19 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
           [applications: [:cog_api]]
         end
 
+## Test
+
+Tests and static analysis can be run with:
+
+```
+bin/test_suite
+```
+
+If tests fail, the script will not perform static analysis.
+
+Run only tests with: `mix test`
+
+## Static Analysis
+
+Run `mix dialyzer` to run analysis. If your dependencies or your elixir version
+change, run `bin/rebuild_plt`.

--- a/bin/rebuild_plt
+++ b/bin/rebuild_plt
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# Exit if any subcommand fails
+set -e
+
+rm .dialyzer.plt
+mix dialyzer.plt

--- a/bin/setup
+++ b/bin/setup
@@ -6,3 +6,5 @@ set -e
 mix local.hex --force
 mix deps.get
 mix compile
+
+./bin/rebuild_plt

--- a/bin/test_suite
+++ b/bin/test_suite
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# Exit if any subcommand fails
+set -e
+
+mix test
+mix dialyzer

--- a/lib/cog_api/client.ex
+++ b/lib/cog_api/client.ex
@@ -1,0 +1,9 @@
+defmodule CogApi.Client do
+  alias CogApi.Endpoint
+  alias CogApi.Resources.Role
+
+  @callback authenticate(%Endpoint{}) :: {atom, %Endpoint{}}
+
+  @callback role_index(%Endpoint{}) :: {atom, [%Role{}]}
+  @callback role_create(%Endpoint{}, %{}) :: {atom, %Role{}}
+end

--- a/lib/cog_api/fake/client.ex
+++ b/lib/cog_api/fake/client.ex
@@ -1,4 +1,6 @@
 defmodule CogApi.Fake.Client do
+  @behaviour CogApi.Client
+
   alias CogApi.Endpoint
   alias CogApi.Fake.Roles
 

--- a/lib/cog_api/http/client.ex
+++ b/lib/cog_api/http/client.ex
@@ -1,4 +1,6 @@
 defmodule CogApi.HTTP.Client do
+  @behaviour CogApi.Client
+
   import CogApi.HTTP.Base
 
   alias CogApi.Endpoint

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,15 @@ defmodule CogApi.Mixfile do
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps,
+      dialyzer: dialyzer_settings,
+    ]
+  end
+
+  defp dialyzer_settings do
+    [
+      plt_add_deps: true,
+      plt_file: ".dialyzer.plt",
+      flags: ["-Wunderspecs", "-Wno_undefined_callbacks"]
     ]
   end
 
@@ -29,6 +38,7 @@ defmodule CogApi.Mixfile do
       {:httpotion, "~> 2.1.0"},
       {:ibrowse, "~> 4.2.2"},
       {:poison, "~> 2.0"},
+      {:dialyxir, "~> 0.3"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"ex_spec": {:hex, :ex_spec, "1.0.0"},
+%{"dialyxir": {:hex, :dialyxir, "0.3.3"},
+  "ex_spec": {:hex, :ex_spec, "1.0.0"},
   "exactor": {:hex, :exactor, "2.2.0"},
   "exjsx": {:hex, :exjsx, "3.2.0"},
   "exvcr": {:hex, :exvcr, "0.7.1"},


### PR DESCRIPTION
Between both behaviours and dialyzer, they are catching _most_ mismatches between implemented functions and correct types. I tried setting this up on CI but didn't have immediate success, so I'll return to that later. For now, you can run dialyzer locally with `mix dialyzer` (you'll have to run `mix dialyzer.plt` once).