### PR TITLE
Require a token for role functions

### DIFF
--- a/lib/cog_api/fake/authentication.ex
+++ b/lib/cog_api/fake/authentication.ex
@@ -1,5 +1,7 @@
 defmodule CogApi.Fake.Authentication do
   alias CogApi.Endpoint
 
-  def get_and_merge_token(%Endpoint{}=endpoint), do: {:ok, endpoint}
+  def get_and_merge_token(%Endpoint{token: nil}=endpoint) do
+    {:ok, %{endpoint | token: "1234"}}
+  end
 end

--- a/lib/cog_api/fake/roles.ex
+++ b/lib/cog_api/fake/roles.ex
@@ -5,12 +5,18 @@ defmodule CogApi.Fake.Roles do
   alias CogApi.Fake.Server
   alias CogApi.Resources.Role
 
-  def role_create(%Endpoint{}, %{name: name}) do
+  def role_create(%Endpoint{token: nil}, %{name: _}), do: invalid_endpoint
+  def role_create(%Endpoint{token: _}, %{name: name}) do
     new_role = %Role{id: random_string(8), name: name}
     {:ok, Server.role_create(new_role)}
   end
 
+  def role_index(%Endpoint{token: nil}),  do: invalid_endpoint
   def role_index(%Endpoint{}) do
     {:ok, Server.role_index}
+  end
+
+  def invalid_endpoint do
+    {:error, "You must provide an authenticated endpoint"}
   end
 end

--- a/test/support/cog_helper.ex
+++ b/test/support/cog_helper.ex
@@ -12,6 +12,11 @@ defmodule CogHelper do
     endpoint
   end
 
+  def fake_endpoint do
+    {:ok, endpoint} = %Endpoint{} |> CogApi.Fake.Client.authenticate
+    endpoint
+  end
+
   def present(string) do
     String.length(string) > 1
   end

--- a/test/unit/cog_api/fake/roles_test.exs
+++ b/test/unit/cog_api/fake/roles_test.exs
@@ -1,13 +1,22 @@
 defmodule CogApi.Fake.RolesTest do
   use CogApi.FakeCase
 
+  alias CogApi.Fake.Roles
+
   doctest CogApi.Fake.Roles
 
   describe "role_create" do
+    it "requires a token" do
+      {response, error_message} = Roles.role_create(%Endpoint{}, %{name: nil})
+
+      assert response == :error
+      assert error_message == "You must provide an authenticated endpoint"
+    end
+
     it "returns the created role" do
       name = "foobar"
       params = %{name: name}
-      {:ok, role} = CogApi.Fake.Roles.role_create(%Endpoint{}, params)
+      {:ok, role} = Roles.role_create(fake_endpoint, params)
 
       assert present role.id
       assert role.name == name
@@ -15,12 +24,19 @@ defmodule CogApi.Fake.RolesTest do
   end
 
   describe "role_index" do
+    it "requires an authenticated endpoint" do
+      {response, error_message} = Roles.role_index(%Endpoint{})
+
+      assert response == :error
+      assert error_message == "You must provide an authenticated endpoint"
+    end
+
     it "returns a list of roles" do
       name = "foobar"
       params = %{name: name}
-      CogApi.Fake.Roles.role_create(%Endpoint{}, params)
+      {:ok, _ } = Roles.role_create(fake_endpoint, params)
 
-      {:ok, roles} = CogApi.Fake.Roles.role_index(%Endpoint{})
+      {:ok, roles} = Roles.role_index(fake_endpoint)
 
       first_role = List.first roles
       assert present first_role.id


### PR DESCRIPTION
The HTTP server will blow up if you provide an endpoint without a token, the fake did not. This changes that! Now if you try and use the fake without a token, the role endpoints will blow up as well.