### PR TITLE
Remove duplication from the individual endpoints

### DIFF
--- a/lib/cog_api/fake/client.ex
+++ b/lib/cog_api/fake/client.ex
@@ -3,28 +3,37 @@ defmodule CogApi.Fake.Client do
 
   alias CogApi.Endpoint
   alias CogApi.Fake.Roles
+  alias CogApi.Fake.Permissions
 
   def authenticate(%Endpoint{token: nil}=endpoint) do
     CogApi.Fake.Authentication.get_and_merge_token(endpoint)
   end
 
   def role_index(endpoint) do
-    Roles.role_index(endpoint)
+    Roles.index(endpoint)
   end
 
   def role_show(endpoint, id) do
-    Roles.role_show(endpoint, id)
+    Roles.show(endpoint, id)
   end
 
   def role_create(endpoint, params) do
-    Roles.role_create(endpoint, params)
+    Roles.create(endpoint, params)
   end
 
   def role_update(endpoint, role_id, params) do
-    Roles.role_update(endpoint, role_id, params)
+    Roles.update(endpoint, role_id, params)
   end
 
   def role_delete(%Endpoint{}=endpoint, role_id) do
-    Roles.role_delete(endpoint, role_id)
+    Roles.delete(endpoint, role_id)
+  end
+
+  def permission_index(%Endpoint{}=endpoint) do
+    Permissions.index(endpoint)
+  end
+
+  def permission_create(%Endpoint{}=endpoint, name) do
+    Permissions.create(endpoint, name)
   end
 end

--- a/lib/cog_api/fake/permissions.ex
+++ b/lib/cog_api/fake/permissions.ex
@@ -6,13 +6,13 @@ defmodule CogApi.Fake.Permissions do
   alias CogApi.Resources.Permission
   alias CogApi.Resources.Namespace
 
-  def permission_index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
-  def permission_index(%Endpoint{}) do
+  def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
+  def index(%Endpoint{}) do
     {:ok, Server.index(:permissions)}
   end
 
-  def permission_create(%Endpoint{token: nil}, %{name: _}), do: Endpoint.invalid_endpoint
-  def permission_create(%Endpoint{token: _}, name) do
+  def create(%Endpoint{token: nil}, %{name: _}), do: Endpoint.invalid_endpoint
+  def create(%Endpoint{token: _}, name) do
     [namespace, name] = build_namespaced_name(name)
 
     new_permission = %Permission{

--- a/lib/cog_api/fake/roles.ex
+++ b/lib/cog_api/fake/roles.ex
@@ -5,29 +5,29 @@ defmodule CogApi.Fake.Roles do
   alias CogApi.Fake.Server
   alias CogApi.Resources.Role
 
-  def role_index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
-  def role_index(%Endpoint{}) do
+  def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
+  def index(%Endpoint{}) do
     {:ok, Server.index(:roles)}
   end
 
-  def role_show(%Endpoint{token: nil}, _),  do: Endpoint.invalid_endpoint
-  def role_show(%Endpoint{}, id) do
+  def show(%Endpoint{token: nil}, _),  do: Endpoint.invalid_endpoint
+  def show(%Endpoint{}, id) do
     {:ok, Server.show(:roles, id)}
   end
 
-  def role_create(%Endpoint{token: nil}, %{name: _}), do: Endpoint.invalid_endpoint
-  def role_create(%Endpoint{token: _}, %{name: name}) do
+  def create(%Endpoint{token: nil}, %{name: _}), do: Endpoint.invalid_endpoint
+  def create(%Endpoint{token: _}, %{name: name}) do
     new_role = %Role{id: random_string(8), name: name}
     {:ok, Server.create(:roles, new_role)}
   end
 
-  def role_update(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
-  def role_update(%Endpoint{token: _}, id, params) do
+  def update(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
+  def update(%Endpoint{token: _}, id, params) do
     {:ok, Server.update(:roles, id, params)}
   end
 
-  def role_delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
-  def role_delete(%Endpoint{token: _}, id) do
+  def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
+  def delete(%Endpoint{token: _}, id) do
     Server.delete(:roles, id)
     :ok
   end

--- a/lib/cog_api/http/client.ex
+++ b/lib/cog_api/http/client.ex
@@ -10,26 +10,30 @@ defmodule CogApi.HTTP.Client do
   end
 
   def role_index(endpoint) do
-    Roles.role_index(endpoint)
+    Roles.index(endpoint)
   end
 
   def role_show(endpoint, id) do
-    Roles.role_show(endpoint, id)
+    Roles.index(endpoint, id)
   end
 
   def role_create(endpoint, params) do
-    Roles.role_create(endpoint, params)
+    Roles.create(endpoint, params)
   end
 
   def role_update(%Endpoint{}=endpoint, role_id, params) do
-    Roles.role_update(endpoint, role_id, params)
+    Roles.update(endpoint, role_id, params)
   end
 
   def role_delete(%Endpoint{}=endpoint, role_id) do
-    Roles.role_delete(endpoint, role_id)
+    Roles.delete(endpoint, role_id)
   end
 
   def permission_index(%Endpoint{}=endpoint) do
-    Permissions.permission_index(endpoint)
+    Permissions.index(endpoint)
+  end
+
+  def permission_create(%Endpoint{}=endpoint, name) do
+    Permissions.create(endpoint, name)
   end
 end

--- a/lib/cog_api/http/permissions.ex
+++ b/lib/cog_api/http/permissions.ex
@@ -1,15 +1,15 @@
 defmodule CogApi.HTTP.Permissions do
-  import CogApi.HTTP.Base
-
   alias CogApi.Endpoint
+  alias CogApi.HTTP.Base
   alias CogApi.Resources.Permission
 
-  def permission_index(%Endpoint{}=endpoint) do
-    get(endpoint, "permissions") |> format_response("permissions", [%Permission{}])
+  def index(%Endpoint{}=endpoint) do
+    Base.get(endpoint, "permissions")
+    |> Base.format_response("permissions", [%Permission{}])
   end
 
-  def permission_create(%Endpoint{}=endpoint, name) do
-    post(endpoint, "permissions", %{"permission" => %{"name" => name}})
-    |> format_response("permission", %Permission{})
+  def create(%Endpoint{}=endpoint, name) do
+    Base.post(endpoint, "permissions", %{"permission" => %{"name" => name}})
+    |> Base.format_response("permission", %Permission{})
   end
 end

--- a/lib/cog_api/http/roles.ex
+++ b/lib/cog_api/http/roles.ex
@@ -1,28 +1,27 @@
 defmodule CogApi.HTTP.Roles do
-  import CogApi.HTTP.Base
-
   alias CogApi.Endpoint
+  alias CogApi.HTTP.Base
   alias CogApi.Resources.Role
 
-  def role_index(%Endpoint{}=endpoint) do
-    get(endpoint, "roles") |> format_response("roles", [%Role{}])
+  def index(%Endpoint{}=endpoint) do
+    Base.get(endpoint, "roles") |> Base.format_response("roles", [%Role{}])
   end
 
-  def role_show(%Endpoint{}=endpoint, id) do
-    get(endpoint, "roles/#{id}") |> format_response("role", %Role{})
+  def show(%Endpoint{}=endpoint, id) do
+    Base.get(endpoint, "roles/#{id}") |> Base.format_response("role", %Role{})
   end
 
-  def role_create(%Endpoint{}=endpoint, params) do
-    post(endpoint, "roles", %{"role" => params})
-    |> format_response("role", %Role{})
+  def create(%Endpoint{}=endpoint, params) do
+    Base.post(endpoint, "roles", %{"role" => params})
+    |> Base.format_response("role", %Role{})
   end
 
-  def role_update(%Endpoint{}=endpoint, role_id, params) do
-    patch(endpoint, "roles/#{role_id}", %{"role" => params})
-    |> format_response("role", %Role{})
+  def update(%Endpoint{}=endpoint, role_id, params) do
+    Base.patch(endpoint, "roles/#{role_id}", %{"role" => params})
+    |> Base.format_response("role", %Role{})
   end
 
-  def role_delete(%Endpoint{}=endpoint, role_id) do
-    delete(endpoint, "roles/#{role_id}") |> format_response("role", %Role{})
+  def delete(%Endpoint{}=endpoint, role_id) do
+    Base.delete(endpoint, "roles/#{role_id}") |> Base.format_response("role", %Role{})
   end
 end

--- a/test/unit/cog_api/fake/permissions_test.exs
+++ b/test/unit/cog_api/fake/permissions_test.exs
@@ -7,9 +7,9 @@ defmodule CogApi.Fake.PermissionsTest do
 
   describe "permission_index" do
     it "returns a list of permissions" do
-      {:ok, _ } = Permissions.permission_create(fake_endpoint, "custom:foobar")
+      {:ok, _ } = Permissions.create(fake_endpoint, "custom:foobar")
 
-      {:ok, permissions} = Permissions.permission_index(fake_endpoint)
+      {:ok, permissions} = Permissions.index(fake_endpoint)
 
       first_permission = List.first permissions
       assert present first_permission.id
@@ -21,7 +21,7 @@ defmodule CogApi.Fake.PermissionsTest do
   describe "permission_create" do
     it "defaults to the site namespace when no `:` is given" do
       name = "view_all_things"
-      {:ok, permission} = Permissions.permission_create(fake_endpoint, name)
+      {:ok, permission} = Permissions.create(fake_endpoint, name)
 
       assert present permission.id
       assert permission.name == "view_all_things"
@@ -31,7 +31,7 @@ defmodule CogApi.Fake.PermissionsTest do
 
     it "allows creating permissions in specifc namespaces" do
       name = "custom:foobar"
-      {:ok, permission} = Permissions.permission_create(fake_endpoint, name)
+      {:ok, permission} = Permissions.create(fake_endpoint, name)
 
       assert present permission.id
       assert permission.name == "foobar"

--- a/test/unit/cog_api/fake/roles_test.exs
+++ b/test/unit/cog_api/fake/roles_test.exs
@@ -7,7 +7,7 @@ defmodule CogApi.Fake.RolesTest do
 
   describe "role_create" do
     it "requires a token" do
-      {response, error_message} = Roles.role_create(%Endpoint{}, %{name: nil})
+      {response, error_message} = Roles.create(%Endpoint{}, %{name: nil})
 
       assert response == :error
       assert error_message == "You must provide an authenticated endpoint"
@@ -16,7 +16,7 @@ defmodule CogApi.Fake.RolesTest do
     it "returns the created role" do
       name = "foobar"
       params = %{name: name}
-      {:ok, role} = Roles.role_create(fake_endpoint, params)
+      {:ok, role} = Roles.create(fake_endpoint, params)
 
       assert present role.id
       assert role.name == name
@@ -27,9 +27,9 @@ defmodule CogApi.Fake.RolesTest do
     context "when the role exists" do
       it "returns the role" do
         params = %{name: "QA Analyst"}
-        {:ok, created_role} = Roles.role_create(fake_endpoint, params)
+        {:ok, created_role} = Roles.create(fake_endpoint, params)
 
-        {:ok, found_role} = Roles.role_show(fake_endpoint, created_role.id)
+        {:ok, found_role} = Roles.show(fake_endpoint, created_role.id)
 
         assert found_role.id == created_role.id
       end
@@ -38,7 +38,7 @@ defmodule CogApi.Fake.RolesTest do
 
   describe "role_index" do
     it "requires an authenticated endpoint" do
-      {response, error_message} = Roles.role_index(%Endpoint{})
+      {response, error_message} = Roles.index(%Endpoint{})
 
       assert response == :error
       assert error_message == "You must provide an authenticated endpoint"
@@ -47,9 +47,9 @@ defmodule CogApi.Fake.RolesTest do
     it "returns a list of roles" do
       name = "foobar"
       params = %{name: name}
-      {:ok, _ } = Roles.role_create(fake_endpoint, params)
+      {:ok, _ } = Roles.create(fake_endpoint, params)
 
-      {:ok, roles} = Roles.role_index(fake_endpoint)
+      {:ok, roles} = Roles.index(fake_endpoint)
 
       first_role = List.first roles
       assert present first_role.id
@@ -59,8 +59,8 @@ defmodule CogApi.Fake.RolesTest do
 
   describe "role_update" do
     it "returns the updated role" do
-      {:ok, new_role} = Roles.role_create(fake_endpoint, %{name: "new role"})
-      {:ok, updated_role} = Roles.role_update(
+      {:ok, new_role} = Roles.create(fake_endpoint, %{name: "new role"})
+      {:ok, updated_role} = Roles.update(
         fake_endpoint,
         new_role.id,
         %{name: "updated role"}
@@ -72,18 +72,18 @@ defmodule CogApi.Fake.RolesTest do
 
   describe "role_delete" do
     it "deletes the role from the server" do
-      {:ok, role} = Roles.role_create(fake_endpoint, %{name: "new role"})
+      {:ok, role} = Roles.create(fake_endpoint, %{name: "new role"})
 
-      Roles.role_delete(fake_endpoint, role.id)
+      Roles.delete(fake_endpoint, role.id)
 
-      {:ok, roles} = Roles.role_index(fake_endpoint)
+      {:ok, roles} = Roles.index(fake_endpoint)
 
       refute Enum.member?(roles, role)
     end
 
     it "returns :ok" do
-      {:ok, role} = Roles.role_create(fake_endpoint, %{name: "new role"})
-      assert :ok == Roles.role_delete(fake_endpoint, role.id)
+      {:ok, role} = Roles.create(fake_endpoint, %{name: "new role"})
+      assert :ok == Roles.delete(fake_endpoint, role.id)
     end
   end
 end

--- a/test/unit/cog_api/http/permissions_test.exs
+++ b/test/unit/cog_api/http/permissions_test.exs
@@ -8,7 +8,7 @@ defmodule CogApi.HTTP.PermissionsTest do
   describe "permission_index" do
     it "returns a list of permissions" do
       cassette "permission_index" do
-        {:ok, permissions} = Permissions.permission_index(valid_endpoint)
+        {:ok, permissions} = Permissions.index(valid_endpoint)
 
         first_permission = List.first permissions
 
@@ -25,7 +25,7 @@ defmodule CogApi.HTTP.PermissionsTest do
     it "returns the created permission, in the site namespace" do
       cassette "permission_create" do
         name = "foobar"
-        {:ok, permission} = Permissions.permission_create(valid_endpoint, name)
+        {:ok, permission} = Permissions.create(valid_endpoint, name)
 
         assert present permission.id
         assert permission.name == "foobar"

--- a/test/unit/cog_api/http/roles_test.exs
+++ b/test/unit/cog_api/http/roles_test.exs
@@ -8,7 +8,7 @@ defmodule CogApi.HTTP.RolesTest do
   describe "role_index" do
     it "returns a list of roles" do
       cassette "roles_index" do
-        {:ok, roles} = Roles.role_index(valid_endpoint)
+        {:ok, roles} = Roles.index(valid_endpoint)
 
         first_role = List.first roles
         assert present first_role.id
@@ -23,9 +23,9 @@ defmodule CogApi.HTTP.RolesTest do
         cassette "roles_show" do
           endpoint = valid_endpoint
           params = %{name: "QA Analyst"}
-          {:ok, created_role} = Roles.role_create(endpoint, params)
+          {:ok, created_role} = Roles.create(endpoint, params)
 
-          {:ok, found_role} = Roles.role_show(endpoint, created_role.id)
+          {:ok, found_role} = Roles.show(endpoint, created_role.id)
 
           assert found_role.id == created_role.id
         end
@@ -37,7 +37,7 @@ defmodule CogApi.HTTP.RolesTest do
     it "returns the created role" do
       cassette "roles_create" do
         params = %{"name" => "new role"}
-        {:ok, role} = Roles.role_create(valid_endpoint, params)
+        {:ok, role} = Roles.create(valid_endpoint, params)
 
         assert present role.id
         assert role.name == "new role"
@@ -49,8 +49,8 @@ defmodule CogApi.HTTP.RolesTest do
     it "returns the updated role" do
       cassette "role_update" do
         endpoint = valid_endpoint
-        {:ok, new_role} = Roles.role_create(endpoint, %{name: "new role"})
-        {:ok, updated_role} = Roles.role_update(
+        {:ok, new_role} = Roles.create(endpoint, %{name: "new role"})
+        {:ok, updated_role} = Roles.update(
           endpoint,
           new_role.id,
           %{name: "updated role"}
@@ -65,8 +65,8 @@ defmodule CogApi.HTTP.RolesTest do
     it "returns :ok" do
       cassette "role_delete" do
         endpoint = valid_endpoint
-        {:ok, role} = Roles.role_create(endpoint, %{name: "role to delete"})
-        assert :ok == Roles.role_delete(endpoint, role.id)
+        {:ok, role} = Roles.create(endpoint, %{name: "role to delete"})
+        assert :ok == Roles.delete(endpoint, role.id)
       end
     end
   end


### PR DESCRIPTION
This removes the duplication in the namespace.

If the external interface of `Client` is being used, this shouldn't change anything.