### PR TITLE
Fix random string generator

### DIFF
--- a/lib/cog_api/fake/random.ex
+++ b/lib/cog_api/fake/random.ex
@@ -1,23 +1,7 @@
 defmodule CogApi.Fake.Random do
-  @on_load :seed_random
-
-  def random_string(digits) do
-    random_number
-    |> to_string
-    |> String.slice(2, digits)
-  end
-
-  def seed_random do
-    :random.seed({
-      :crypto.rand_uniform(1, 99999),
-      :crypto.rand_uniform(1, 99999),
-      :crypto.rand_uniform(1, 99999)
-    })
-
-    :ok
-  end
-
-  defp random_number do
-    :random.uniform
+  def random_string(length) do
+    :crypto.strong_rand_bytes(length)
+    |> Base.url_encode64
+    |> binary_part(0, length)
   end
 end


### PR DESCRIPTION
The previous random string generator was still being seeded with the
same numbers. Tested this against Flywheel to make sure it's working
correctly.