### PR TITLE
Force recompile when running full test suite

### DIFF
--- a/bin/test_suite
+++ b/bin/test_suite
@@ -3,5 +3,5 @@
 # Exit if any subcommand fails
 set -e
 
-mix test --warnings-as-errors
+mix test --warnings-as-errors --force
 mix dialyzer


### PR DESCRIPTION
It won't catch warnings in files that don't have to be compiled, so this
forces the project to be recompiled to catch any warnings. Adds a little
time locally, but potentially saves time from having it pass locally but
fail on CI.