### PR TITLE
Fix user functions and test through client

### DIFF
--- a/lib/cog_api/fake/client.ex
+++ b/lib/cog_api/fake/client.ex
@@ -6,6 +6,7 @@ defmodule CogApi.Fake.Client do
   alias CogApi.Fake.Roles
   alias CogApi.Fake.Permissions
   alias CogApi.Fake.Bundles
+  alias CogApi.Fake.Users
 
   def authenticate(%Endpoint{token: nil}=endpoint) do
     CogApi.Fake.Authentication.get_and_merge_token(endpoint)
@@ -56,10 +57,10 @@ defmodule CogApi.Fake.Client do
   end
 
   def user_index(endpoint) do
-    Roles.index(endpoint)
+    Users.index(endpoint)
   end
 
   def user_create(endpoint, params) do
-    Roles.create(endpoint, params)
+    Users.create(endpoint, params)
   end
 end

--- a/lib/cog_api/http/client.ex
+++ b/lib/cog_api/http/client.ex
@@ -6,6 +6,7 @@ defmodule CogApi.HTTP.Client do
   alias CogApi.HTTP.Roles
   alias CogApi.HTTP.Permissions
   alias CogApi.HTTP.Bundles
+  alias CogApi.HTTP.Users
 
   def authenticate(%Endpoint{token: nil}=endpoint) do
     CogApi.HTTP.Authentication.get_and_merge_token(endpoint)
@@ -56,10 +57,10 @@ defmodule CogApi.HTTP.Client do
   end
 
   def user_index(endpoint) do
-    Roles.index(endpoint)
+    Users.index(endpoint)
   end
 
   def user_create(endpoint, params) do
-    Roles.create(endpoint, params)
+    Users.create(endpoint, params)
   end
 end

--- a/test/unit/cog_api/fake/bundles_test.exs
+++ b/test/unit/cog_api/fake/bundles_test.exs
@@ -3,13 +3,13 @@ defmodule CogApi.Fake.BundlesTest do
 
   alias CogApi.Resources.Bundle
   alias CogApi.Fake.Server
-  alias CogApi.Fake.Bundles
+  alias CogApi.Fake.Client
 
   doctest CogApi.Fake.Roles
 
   describe "bundle_index" do
     it "requires an authenticated endpoint" do
-      {response, error_message} = Bundles.index(%Endpoint{})
+      {response, error_message} = Client.bundle_index(%Endpoint{})
 
       assert response == :error
       assert error_message == "You must provide an authenticated endpoint"
@@ -19,7 +19,7 @@ defmodule CogApi.Fake.BundlesTest do
       bundle = %Bundle{id: "id123", name: "a bundle"}
       Server.create(:bundles, bundle)
 
-      {:ok, bundles} = Bundles.index(fake_endpoint)
+      {:ok, bundles} = Client.bundle_index(fake_endpoint)
 
       first_bundle = List.first bundles
       assert first_bundle.id == bundle.id

--- a/test/unit/cog_api/fake/groups_test.exs
+++ b/test/unit/cog_api/fake/groups_test.exs
@@ -1,16 +1,16 @@
 defmodule CogApi.Fake.GroupsTest do
   use CogApi.FakeCase
 
-  alias CogApi.Fake.Groups
+  alias CogApi.Fake.Client
 
   doctest CogApi.Fake.Groups
 
   describe "group_index" do
     it "returns a list of groups" do
       name = "foobar"
-      {:ok, _ } = Groups.create(fake_endpoint, %{name: name})
+      {:ok, _ } = Client.group_create(fake_endpoint, %{name: name})
 
-      {:ok, groups} = Groups.index(fake_endpoint)
+      {:ok, groups} = Client.group_index(fake_endpoint)
 
       first_group = List.first groups
       assert present first_group.id
@@ -22,9 +22,9 @@ defmodule CogApi.Fake.GroupsTest do
     context "when the group exists" do
       it "returns the group" do
         params = %{name: "Developers"}
-        {:ok, created_group} = Groups.create(fake_endpoint, params)
+        {:ok, created_group} = Client.group_create(fake_endpoint, params)
 
-        {:ok, found_group} = Groups.show(fake_endpoint, created_group.id)
+        {:ok, found_group} = Client.group_show(fake_endpoint, created_group.id)
 
         assert found_group.id == created_group.id
       end
@@ -34,7 +34,7 @@ defmodule CogApi.Fake.GroupsTest do
   describe "create" do
     it "returns the created group" do
       name = "foobar"
-      {:ok, group} = Groups.create(fake_endpoint, %{name: name})
+      {:ok, group} = Client.group_create(fake_endpoint, %{name: name})
 
       assert present group.id
       assert group.name == name

--- a/test/unit/cog_api/fake/permissions_test.exs
+++ b/test/unit/cog_api/fake/permissions_test.exs
@@ -1,15 +1,15 @@
 defmodule CogApi.Fake.PermissionsTest do
   use CogApi.FakeCase
 
-  alias CogApi.Fake.Permissions
+  alias CogApi.Fake.Client
 
   doctest CogApi.Fake.Permissions
 
   describe "permission_index" do
     it "returns a list of permissions" do
-      {:ok, _ } = Permissions.create(fake_endpoint, "custom:foobar")
+      {:ok, _ } = Client.permission_create(fake_endpoint, "custom:foobar")
 
-      {:ok, permissions} = Permissions.index(fake_endpoint)
+      {:ok, permissions} = Client.permission_index(fake_endpoint)
 
       first_permission = List.first permissions
       assert present first_permission.id
@@ -21,7 +21,7 @@ defmodule CogApi.Fake.PermissionsTest do
   describe "permission_create" do
     it "defaults to the site namespace when no `:` is given" do
       name = "view_all_things"
-      {:ok, permission} = Permissions.create(fake_endpoint, name)
+      {:ok, permission} = Client.permission_create(fake_endpoint, name)
 
       assert present permission.id
       assert permission.name == "view_all_things"
@@ -31,7 +31,7 @@ defmodule CogApi.Fake.PermissionsTest do
 
     it "allows creating permissions in specifc namespaces" do
       name = "custom:foobar"
-      {:ok, permission} = Permissions.create(fake_endpoint, name)
+      {:ok, permission} = Client.permission_create(fake_endpoint, name)
 
       assert present permission.id
       assert permission.name == "foobar"

--- a/test/unit/cog_api/fake/roles_test.exs
+++ b/test/unit/cog_api/fake/roles_test.exs
@@ -1,13 +1,13 @@
 defmodule CogApi.Fake.RolesTest do
   use CogApi.FakeCase
 
-  alias CogApi.Fake.Roles
+  alias CogApi.Fake.Client
 
   doctest CogApi.Fake.Roles
 
   describe "role_create" do
     it "requires a token" do
-      {response, error_message} = Roles.create(%Endpoint{}, %{name: nil})
+      {response, error_message} = Client.role_create(%Endpoint{}, %{name: nil})
 
       assert response == :error
       assert error_message == "You must provide an authenticated endpoint"
@@ -16,7 +16,7 @@ defmodule CogApi.Fake.RolesTest do
     it "returns the created role" do
       name = "foobar"
       params = %{name: name}
-      {:ok, role} = Roles.create(fake_endpoint, params)
+      {:ok, role} = Client.role_create(fake_endpoint, params)
 
       assert present role.id
       assert role.name == name
@@ -27,9 +27,9 @@ defmodule CogApi.Fake.RolesTest do
     context "when the role exists" do
       it "returns the role" do
         params = %{name: "QA Analyst"}
-        {:ok, created_role} = Roles.create(fake_endpoint, params)
+        {:ok, created_role} = Client.role_create(fake_endpoint, params)
 
-        {:ok, found_role} = Roles.show(fake_endpoint, created_role.id)
+        {:ok, found_role} = Client.role_show(fake_endpoint, created_role.id)
 
         assert found_role.id == created_role.id
       end
@@ -38,7 +38,7 @@ defmodule CogApi.Fake.RolesTest do
 
   describe "role_index" do
     it "requires an authenticated endpoint" do
-      {response, error_message} = Roles.index(%Endpoint{})
+      {response, error_message} = Client.role_index(%Endpoint{})
 
       assert response == :error
       assert error_message == "You must provide an authenticated endpoint"
@@ -47,9 +47,9 @@ defmodule CogApi.Fake.RolesTest do
     it "returns a list of roles" do
       name = "foobar"
       params = %{name: name}
-      {:ok, _} = Roles.create(fake_endpoint, params)
+      {:ok, _} = Client.role_create(fake_endpoint, params)
 
-      {:ok, roles} = Roles.index(fake_endpoint)
+      {:ok, roles} = Client.role_index(fake_endpoint)
 
       first_role = List.first roles
       assert present first_role.id
@@ -59,8 +59,8 @@ defmodule CogApi.Fake.RolesTest do
 
   describe "role_update" do
     it "returns the updated role" do
-      {:ok, new_role} = Roles.create(fake_endpoint, %{name: "new role"})
-      {:ok, updated_role} = Roles.update(
+      {:ok, new_role} = Client.role_create(fake_endpoint, %{name: "new role"})
+      {:ok, updated_role} = Client.role_update(
         fake_endpoint,
         new_role.id,
         %{name: "updated role"}
@@ -72,18 +72,18 @@ defmodule CogApi.Fake.RolesTest do
 
   describe "role_delete" do
     it "deletes the role from the server" do
-      {:ok, role} = Roles.create(fake_endpoint, %{name: "new role"})
+      {:ok, role} = Client.role_create(fake_endpoint, %{name: "new role"})
 
-      Roles.delete(fake_endpoint, role.id)
+      Client.role_delete(fake_endpoint, role.id)
 
-      {:ok, roles} = Roles.index(fake_endpoint)
+      {:ok, roles} = Client.role_index(fake_endpoint)
 
       refute Enum.member?(roles, role)
     end
 
     it "returns :ok" do
-      {:ok, role} = Roles.create(fake_endpoint, %{name: "new role"})
-      assert :ok == Roles.delete(fake_endpoint, role.id)
+      {:ok, role} = Client.role_create(fake_endpoint, %{name: "new role"})
+      assert :ok == Client.role_delete(fake_endpoint, role.id)
     end
   end
 end

--- a/test/unit/cog_api/fake/users_test.exs
+++ b/test/unit/cog_api/fake/users_test.exs
@@ -1,7 +1,7 @@
 defmodule CogApi.Fake.UsersTest do
   use CogApi.FakeCase
 
-  alias CogApi.Fake.Users
+  alias CogApi.Fake.Client
 
   doctest CogApi.Fake.Users
 
@@ -14,9 +14,9 @@ defmodule CogApi.Fake.UsersTest do
         username: "chief_of_staff",
         password: "supersecret",
       }
-      {:ok, _} = Users.create(fake_endpoint, params)
+      {:ok, _} = Client.user_create(fake_endpoint, params)
 
-      {:ok, users} = Users.index(fake_endpoint)
+      {:ok, users} = Client.user_index(fake_endpoint)
 
       last_user = List.last users
       assert present last_user.id
@@ -36,7 +36,7 @@ defmodule CogApi.Fake.UsersTest do
         username: "chief_of_staff",
         password: "supersecret",
       }
-      {:ok, user} = Users.create(fake_endpoint, params)
+      {:ok, user} = Client.user_create(fake_endpoint, params)
 
       assert present user.id
       assert user.first_name == params.first_name

--- a/test/unit/cog_api/http/bundles_test.exs
+++ b/test/unit/cog_api/http/bundles_test.exs
@@ -1,14 +1,14 @@
 defmodule CogApi.HTTP.BundlesTest do
   use CogApi.HTTPCase
 
-  alias CogApi.HTTP.Bundles
+  alias CogApi.HTTP.Client
 
   doctest CogApi.HTTP.Bundles
 
   describe "bundle_index" do
     it "returns a list of bundles" do
       cassette "bundles_index" do
-        {:ok, bundles} = Bundles.index(valid_endpoint)
+        {:ok, bundles} = Client.bundle_index(valid_endpoint)
 
         first_bundle = List.first bundles
         assert present first_bundle.id

--- a/test/unit/cog_api/http/groups_test.exs
+++ b/test/unit/cog_api/http/groups_test.exs
@@ -1,14 +1,14 @@
 defmodule CogApi.HTTP.GroupsTest do
   use CogApi.HTTPCase
 
-  alias CogApi.HTTP.Groups
+  alias CogApi.HTTP.Client
 
   doctest CogApi.HTTP.Groups
 
   describe "group_index" do
     it "returns a list of groups" do
       cassette "groups_index" do
-        {:ok, groups} = Groups.index(valid_endpoint)
+        {:ok, groups} = Client.group_index(valid_endpoint)
 
         first_group = List.first groups
         assert present first_group.id
@@ -23,9 +23,9 @@ defmodule CogApi.HTTP.GroupsTest do
         cassette "groups_show" do
           endpoint = valid_endpoint
           params = %{name: "Developers"}
-          {:ok, created_group} = Groups.create(endpoint, params)
+          {:ok, created_group} = Client.group_create(endpoint, params)
 
-          {:ok, found_group} = Groups.show(endpoint, created_group.id)
+          {:ok, found_group} = Client.group_show(endpoint, created_group.id)
 
           assert found_group.id == created_group.id
         end
@@ -37,7 +37,7 @@ defmodule CogApi.HTTP.GroupsTest do
     it "returns the created group" do
       cassette "groups_create" do
         name = "new group"
-        {:ok, group} = Groups.create(valid_endpoint, %{name: name})
+        {:ok, group} = Client.group_create(valid_endpoint, %{name: name})
 
         assert present group.id
         assert group.name == name

--- a/test/unit/cog_api/http/permissions_test.exs
+++ b/test/unit/cog_api/http/permissions_test.exs
@@ -1,14 +1,14 @@
 defmodule CogApi.HTTP.PermissionsTest do
   use CogApi.HTTPCase
 
-  alias CogApi.HTTP.Permissions
+  alias CogApi.HTTP.Client
 
   doctest CogApi.HTTP.Permissions
 
   describe "permission_index" do
     it "returns a list of permissions" do
       cassette "permission_index" do
-        {:ok, permissions} = Permissions.index(valid_endpoint)
+        {:ok, permissions} = Client.permission_index(valid_endpoint)
 
         first_permission = List.first permissions
 
@@ -25,7 +25,7 @@ defmodule CogApi.HTTP.PermissionsTest do
     it "returns the created permission, in the site namespace" do
       cassette "permission_create" do
         name = "foobar"
-        {:ok, permission} = Permissions.create(valid_endpoint, name)
+        {:ok, permission} = Client.permission_create(valid_endpoint, name)
 
         assert present permission.id
         assert permission.name == "foobar"

--- a/test/unit/cog_api/http/roles_test.exs
+++ b/test/unit/cog_api/http/roles_test.exs
@@ -1,14 +1,14 @@
 defmodule CogApi.HTTP.RolesTest do
   use CogApi.HTTPCase
 
-  alias CogApi.HTTP.Roles
+  alias CogApi.HTTP.Client
 
   doctest CogApi.HTTP.Roles
 
   describe "role_index" do
     it "returns a list of roles" do
       cassette "roles_index" do
-        {:ok, roles} = Roles.index(valid_endpoint)
+        {:ok, roles} = Client.role_index(valid_endpoint)
 
         first_role = List.first roles
         assert present first_role.id
@@ -23,9 +23,9 @@ defmodule CogApi.HTTP.RolesTest do
         cassette "roles_show" do
           endpoint = valid_endpoint
           params = %{name: "QA Analyst"}
-          {:ok, created_role} = Roles.create(endpoint, params)
+          {:ok, created_role} = Client.role_create(endpoint, params)
 
-          {:ok, found_role} = Roles.show(endpoint, created_role.id)
+          {:ok, found_role} = Client.role_show(endpoint, created_role.id)
 
           assert found_role.id == created_role.id
         end
@@ -37,7 +37,7 @@ defmodule CogApi.HTTP.RolesTest do
     it "returns the created role" do
       cassette "roles_create" do
         params = %{"name" => "new role"}
-        {:ok, role} = Roles.create(valid_endpoint, params)
+        {:ok, role} = Client.role_create(valid_endpoint, params)
 
         assert present role.id
         assert role.name == "new role"
@@ -49,8 +49,8 @@ defmodule CogApi.HTTP.RolesTest do
     it "returns the updated role" do
       cassette "role_update" do
         endpoint = valid_endpoint
-        {:ok, new_role} = Roles.create(endpoint, %{name: "new role"})
-        {:ok, updated_role} = Roles.update(
+        {:ok, new_role} = Client.role_create(endpoint, %{name: "new role"})
+        {:ok, updated_role} = Client.role_update(
           endpoint,
           new_role.id,
           %{name: "updated role"}
@@ -65,8 +65,8 @@ defmodule CogApi.HTTP.RolesTest do
     it "returns :ok" do
       cassette "role_delete" do
         endpoint = valid_endpoint
-        {:ok, role} = Roles.create(endpoint, %{name: "role to delete"})
-        assert :ok == Roles.delete(endpoint, role.id)
+        {:ok, role} = Client.role_create(endpoint, %{name: "role to delete"})
+        assert :ok == Client.role_delete(endpoint, role.id)
       end
     end
   end

--- a/test/unit/cog_api/http/users_test.exs
+++ b/test/unit/cog_api/http/users_test.exs
@@ -1,7 +1,7 @@
 defmodule CogApi.HTTP.UsersTest do
   use CogApi.HTTPCase
 
-  alias CogApi.HTTP.Users
+  alias CogApi.HTTP.Client
 
   doctest CogApi.HTTP.Users
 
@@ -16,9 +16,9 @@ defmodule CogApi.HTTP.UsersTest do
           password: "supersecret",
         }
         endpoint = valid_endpoint
-        {:ok, _} = Users.create(endpoint, params)
+        {:ok, _} = Client.user_create(endpoint, params)
 
-        {:ok, users} = Users.index(endpoint)
+        {:ok, users} = Client.user_index(endpoint)
 
         last_user = List.last users
         assert present last_user.id
@@ -40,7 +40,7 @@ defmodule CogApi.HTTP.UsersTest do
           username: "potus",
           password: "mrpresident",
         }
-        {:ok, user} = Users.create(valid_endpoint, params)
+        {:ok, user} = Client.user_create(valid_endpoint, params)
 
         assert present user.id
         assert user.first_name == params.first_name


### PR DESCRIPTION
Our previous method of testing the internal functions directly wasn't
catching errors in the user facing clients themselves. This moves all
unit tests to test _through_ the Fake.Client and HTTP.Client to ensure
we are covering all cases.