### PR TITLE
Add the ability to grant roles to a group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+* The `role_grant` function now takes a `%Role{}`, and a `%Group{}` instead of
+  names. It returns a `%Group{}` with the associated roles as an attribute. The
+  original `role_grant` can still be used for users.
+
 * The `bundle_status`, `bundle_enable` and `bundle_disable` functions were
   removed. All calls should now go through `bundle_update` and pass the
   `enabled:` as `true` or `false`. This command returns `{:ok, %Bundle}`.

--- a/lib/cog_api/client.ex
+++ b/lib/cog_api/client.ex
@@ -23,6 +23,7 @@ defmodule CogApi.Client do
   @callback role_create(%Endpoint{}, %{}) :: {atom, %Role{}}
   @callback role_update(%Endpoint{}, String.t, %{}) :: {atom, %Role{}}
   @callback role_delete(%Endpoint{}, String.t) :: atom
+  @callback role_grant(%Endpoint{}, %Role{}, %Group{}) :: {atom, %Group{}}
 
   @callback user_index(%Endpoint{}) :: {atom, [%User{}]}
   @callback user_show(%Endpoint{}, String.t) :: {atom, %User{}}

--- a/lib/cog_api/fake/client.ex
+++ b/lib/cog_api/fake/client.ex
@@ -60,6 +60,10 @@ defmodule CogApi.Fake.Client do
     Roles.delete(endpoint, role_id)
   end
 
+  def role_grant(%Endpoint{}=endpoint, role, group) do
+    Roles.grant(endpoint, role, group)
+  end
+
   def user_index(%Endpoint{}=endpoint) do
     Users.index(endpoint)
   end

--- a/lib/cog_api/fake/roles.ex
+++ b/lib/cog_api/fake/roles.ex
@@ -31,4 +31,10 @@ defmodule CogApi.Fake.Roles do
     Server.delete(:roles, id)
     :ok
   end
+
+  def grant(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
+  def grant(%Endpoint{}, role, group) do
+    group = %{group | roles: group.roles ++ [role]}
+    {:ok, Server.update(:groups, group.id, group)}
+  end
 end

--- a/lib/cog_api/http/base.ex
+++ b/lib/cog_api/http/base.ex
@@ -112,7 +112,7 @@ defmodule CogApi.HTTP.Base do
     route = if is_function(route) do
       route.()
     else
-      route
+      URI.encode(route)
     end
     url = "#{proto}://#{host}:#{port}/v#{version}"
     url = if String.starts_with?(route, "/") do

--- a/lib/cog_api/http/client.ex
+++ b/lib/cog_api/http/client.ex
@@ -60,6 +60,10 @@ defmodule CogApi.HTTP.Client do
     Roles.delete(endpoint, role_id)
   end
 
+  def role_grant(%Endpoint{}=endpoint, role, group) do
+    Roles.grant(endpoint, role, group)
+  end
+
   def user_index(%Endpoint{}=endpoint) do
     Users.index(endpoint)
   end

--- a/lib/cog_api/http/old.ex
+++ b/lib/cog_api/http/old.ex
@@ -144,12 +144,10 @@ defmodule CogApi.HTTP.Old do
   end
 
   def role_grant(%Endpoint{}=endpoint, role_name, type, item_to_grant)
-      when type in ["users", "groups"] do
+      when type in ["users"] do
     result = case type do
       "users" ->
         find_id_by(endpoint, type, username: item_to_grant)
-      "groups" ->
-        find_id_by(endpoint, type, name: item_to_grant)
     end
 
     with {:ok, id} <- result do

--- a/lib/cog_api/http/roles.ex
+++ b/lib/cog_api/http/roles.ex
@@ -24,4 +24,18 @@ defmodule CogApi.HTTP.Roles do
   def delete(%Endpoint{}=endpoint, role_id) do
     Base.delete(endpoint, "roles/#{role_id}") |> Base.format_response("role", %Role{})
   end
+
+  def grant(%Endpoint{}=endpoint, role, group) do
+    path = "groups/#{group.id}/roles"
+    Base.post(endpoint, path, %{roles: %{grant: [role.name]}})
+    |> format_response(group)
+  end
+
+  defp format_response(response, group) do
+    body = Poison.decode!(response.body, as: %{"roles" => [%Role{}]})
+    {
+      Base.response_type(response),
+      %{group | roles: body["roles"] }
+    }
+  end
 end

--- a/lib/cog_api/resources/group.ex
+++ b/lib/cog_api/resources/group.ex
@@ -4,5 +4,6 @@ defmodule CogApi.Resources.Group do
   defstruct [
     :id,
     :name,
+    roles: [],
   ]
 end

--- a/test/fixtures/vcr/role_grant.json
+++ b/test/fixtures/vcr/role_grant.json
@@ -1,0 +1,107 @@
+[
+  {
+    "request": {
+      "body": "{\"username\":\"admin\",\"password\":\"password\"}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/token"
+    },
+    "response": {
+      "body": "{\"token\":{\"value\":\"WWIlSkemnwDatFLu+nqisp2a17uqilP3RHXghUbSbHA=\"}}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Thu, 17 Mar 2016 18:56:39 GMT",
+        "content-length": "66",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "s0gimnof06jnong199ejlp9ref6b9ain"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "{\"role\":{\"name\":\"role\"}}",
+      "headers": {
+        "authorization": "token WWIlSkemnwDatFLu+nqisp2a17uqilP3RHXghUbSbHA=",
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/roles"
+    },
+    "response": {
+      "body": "{\"role\":{\"name\":\"role\",\"id\":\"6ce4abcc-fa67-4523-a3d6-356603dfaa4e\"}}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Thu, 17 Mar 2016 18:56:39 GMT",
+        "content-length": "70",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "tdr3ks3gml4shuessskevhr6j1adgu6m",
+        "location": "/v1/roles/6ce4abcc-fa67-4523-a3d6-356603dfaa4e"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "{\"group\":{\"name\":\"group\"}}",
+      "headers": {
+        "authorization": "token WWIlSkemnwDatFLu+nqisp2a17uqilP3RHXghUbSbHA=",
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/groups"
+    },
+    "response": {
+      "body": "{\"group\":{\"name\":\"group\",\"id\":\"3f655fa2-17e2-435f-9ef1-2b21b8d7248a\"}}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Thu, 17 Mar 2016 18:56:39 GMT",
+        "content-length": "73",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "r9ns66i7k2cg7p93ggvcsoo76n91p1ja",
+        "location": "/v1/groups/3f655fa2-17e2-435f-9ef1-2b21b8d7248a"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "{\"roles\":{\"grant\":[\"role\"]}}",
+      "headers": {
+        "authorization": "token WWIlSkemnwDatFLu+nqisp2a17uqilP3RHXghUbSbHA=",
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/groups/3f655fa2-17e2-435f-9ef1-2b21b8d7248a/roles"
+    },
+    "response": {
+      "body": "{\"roles\":[{\"name\":\"role\",\"id\":\"6ce4abcc-fa67-4523-a3d6-356603dfaa4e\"}]}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Thu, 17 Mar 2016 18:56:40 GMT",
+        "content-length": "73",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "1a7nk89m9ulpncqbo6gl5u0hubcue8j3"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/unit/cog_api/fake/roles_test.exs
+++ b/test/unit/cog_api/fake/roles_test.exs
@@ -86,4 +86,16 @@ defmodule CogApi.Fake.RolesTest do
       assert :ok == Client.role_delete(fake_endpoint, role.id)
     end
   end
+
+  describe "role_grant" do
+    it "returns the roles that are associated with that group" do
+      role = Client.role_create(fake_endpoint, %{name: "role"}) |> get_value
+      group = Client.group_create(fake_endpoint, %{name: "group"}) |> get_value
+
+      updated_group = Client.role_grant(fake_endpoint, role, group) |> get_value
+
+      first_role = List.first updated_group.roles
+      assert first_role.id == role.id
+    end
+  end
 end

--- a/test/unit/cog_api/http/roles_test.exs
+++ b/test/unit/cog_api/http/roles_test.exs
@@ -70,4 +70,19 @@ defmodule CogApi.HTTP.RolesTest do
       end
     end
   end
+
+  describe "role_grant" do
+    it "returns the roles that are associated with that group" do
+      cassette "role_grant" do
+        endpoint = valid_endpoint
+        role = Client.role_create(endpoint, %{name: "role"}) |> get_value
+        group = Client.group_create(endpoint, %{name: "group"}) |> get_value
+
+        updated_group = Client.role_grant(endpoint, role, group) |> get_value
+
+        first_role = List.first updated_group.roles
+        assert first_role.id == role.id
+      end
+    end
+  end
 end


### PR DESCRIPTION
Note: the API needs a role name to update. It felt weird asking for the role name so we decided to take in full structs for the group and role. Passing in the group also allows us to update the roles associated with that group so that if someone want to update a UI with the groups, it will be available.