### PR TITLE
Update the users on a group properly

### DIFF
--- a/lib/cog_api/fake/groups.ex
+++ b/lib/cog_api/fake/groups.ex
@@ -23,7 +23,10 @@ defmodule CogApi.Fake.Groups do
 
   def add_user(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def add_user(%Endpoint{token: _}, group, user) do
-    group = %{group | users: group.users ++ [user]}
+    group = Server.show(:groups, group.id)
+    users = group.users ++ [user]
+    group = %{group | users: users}
+
     {:ok, Server.update(:groups, group.id, group)}
   end
 end

--- a/test/unit/cog_api/fake/groups_test.exs
+++ b/test/unit/cog_api/fake/groups_test.exs
@@ -44,12 +44,14 @@ defmodule CogApi.Fake.GroupsTest do
   describe "group_add_user" do
     it "adds the user to the group" do
       group = Client.group_create(fake_endpoint, %{name: "user_group"}) |> get_value
-      user = Client.user_create(fake_endpoint, %{username: "bob"}) |> get_value
+      first_user = Client.user_create(fake_endpoint, %{username: "bob"}) |> get_value
+      second_user = Client.user_create(fake_endpoint, %{username: "sam"}) |> get_value
       assert group.users == []
 
-      group = Client.group_add_user(fake_endpoint, group, user) |> get_value
+      Client.group_add_user(fake_endpoint, group, first_user) |> get_value
+      group = Client.group_add_user(fake_endpoint, group, second_user) |> get_value
 
-      assert group.users == [user]
+      assert group.users == [first_user, second_user]
     end
   end
 end


### PR DESCRIPTION
Previously, if you added a user to the group, it would only keep the users that
were on the group passed to the function. If you done this:

```
group = create_group
add_user(group, first_user)
add_user(group, second_user)
group = group_show
```

The final `group.users` would only include the `second_user` and not the first.

This resolves the issue by treating the `group.users` from the server as the
single source of truth.