### PR TITLE
Consistent error handling *NOT for merging into HEAD*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /deps
 erl_crash.dump
 *.ez
+*.swp
 .dialyzer.plt

--- a/lib/cog_api/http/authentication.ex
+++ b/lib/cog_api/http/authentication.ex
@@ -7,7 +7,7 @@ defmodule CogApi.HTTP.Authentication do
     params = %{username: endpoint.username, password: endpoint.password}
 
     post(endpoint, "token", params)
-    |> format_response
+    |> format_generic_response
     |> merge_token(endpoint)
   end
 

--- a/lib/cog_api/http/base.ex
+++ b/lib/cog_api/http/base.ex
@@ -58,7 +58,7 @@ defmodule CogApi.HTTP.Base do
         %{"id" => id} ->
           {:ok, id}
         nil ->
-          {:error, %{"error" => "Resource not found"}}
+          {:error, %{"errors" => "Resource not found"}}
       end
     end
   end
@@ -88,8 +88,12 @@ defmodule CogApi.HTTP.Base do
       Poison.decode!(response.body)
     }
   end
+
   def format_response(response = {:error, _}, _, _), do: response
   def format_response(%Response{status_code: 204}, _, _), do: :ok
+  def format_response(%Response{status_code: code}=response, _, _) when code in [403, 422] do
+    format_error(response)
+  end
   def format_response(response = %Response{}, resource, struct) do
     {
       response_type(response),
@@ -103,7 +107,7 @@ defmodule CogApi.HTTP.Base do
   defp format_error(response) do
     {
       :error,
-      Poison.decode!(response.body)["error"]
+      Poison.decode!(response.body)["errors"]
     }
   end
 

--- a/lib/cog_api/http/old.ex
+++ b/lib/cog_api/http/old.ex
@@ -63,7 +63,7 @@ defmodule CogApi.HTTP.Old do
         %{"id" => id} ->
           {:ok, id}
         nil ->
-          {:error, %{"error" => "Resource not found"}}
+          {:error, %{"errors" => "Resource not found"}}
       end
     end
   end
@@ -243,7 +243,7 @@ defmodule CogApi.HTTP.Old do
       fun.()
     rescue
       HTTPotion.HTTPError ->
-        {:error, %{"error" => "An instance of cog must be running"}}
+        {:error, %{"errors" => "An instance of cog must be running"}}
     end
   end
 

--- a/test/fixtures/vcr/authenticate_invalid_credentials.json
+++ b/test/fixtures/vcr/authenticate_invalid_credentials.json
@@ -11,7 +11,7 @@
       "url": "http://localhost:4000/v1/token"
     },
     "response": {
-      "body": "{\"error\":\"Invalid username/password\"}",
+      "body": "{\"errors\":\"Invalid username/password\"}",
       "headers": {
         "server": "Cowboy",
         "date": "Fri, 11 Mar 2016 16:00:22 GMT",

--- a/test/fixtures/vcr/users_create_errors.json
+++ b/test/fixtures/vcr/users_create_errors.json
@@ -1,0 +1,53 @@
+[
+  {
+    "request": {
+      "body": "{\"username\":\"admin\",\"password\":\"password\"}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/token"
+    },
+    "response": {
+      "body": "{\"token\":{\"value\":\"z9dq0qkckmoA5pem5FIswvycHG0UU649p8AiQ4LctZ8=\"}}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 22 Mar 2016 15:55:19 GMT",
+        "content-length": "66",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "4beb2sg2tiamnciulvsjbtsjbrk02epf"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "{\"user\":{\"username\":\"potus\",\"password\":\"mrpresident\",\"email_address\":\"president@example.com\"}}",
+      "headers": {
+        "authorization": "token z9dq0qkckmoA5pem5FIswvycHG0UU649p8AiQ4LctZ8=",
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/users"
+    },
+    "response": {
+      "body": "{\"errors\":{\"last_name\":[\"can't be blank\"],\"first_name\":[\"can't be blank\"]}}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 22 Mar 2016 15:55:21 GMT",
+        "content-length": "75",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "iog8a3j793cv2ujemsthauqih208br5g"
+      },
+      "status_code": 422,
+      "type": "ok"
+    }
+  }
+]

--- a/test/unit/cog_api/http/authentication_test.exs
+++ b/test/unit/cog_api/http/authentication_test.exs
@@ -31,9 +31,9 @@ defmodule CogApi.HTTP.AuthenticationTest do
             host: "localhost",
             port: invalid_port,
           }
-          {:no_connection_error, error_message} = Authentication.get_and_merge_token(endpoint)
+          {:error, errors} = Authentication.get_and_merge_token(endpoint)
 
-          assert error_message == "An instance of cog must be running"
+          assert errors == ["Could not connect to a Cog instance"]
         end
       end
     end
@@ -47,9 +47,9 @@ defmodule CogApi.HTTP.AuthenticationTest do
             host: "localhost",
             port: "4000",
           }
-          {:error, error_message} = Authentication.get_and_merge_token(endpoint)
+          {:error, errors} = Authentication.get_and_merge_token(endpoint)
 
-          assert error_message == "Invalid username/password"
+          assert errors == ["Invalid username/password"]
         end
       end
     end

--- a/test/unit/cog_api/http/users_test.exs
+++ b/test/unit/cog_api/http/users_test.exs
@@ -71,6 +71,22 @@ defmodule CogApi.HTTP.UsersTest do
         assert user.username == params.username
       end
     end
+
+    it "returns errors when invalid" do
+      cassette "users_create_errors" do
+        params = %{
+          email_address: "president@example.com",
+          username: "potus",
+          password: "mrpresident",
+        }
+        {:error, errors} = Client.user_create(valid_endpoint, params)
+
+        assert errors == [
+          "First name can't be blank",
+          "Last name can't be blank",
+        ]
+      end
+    end
   end
 
   describe "update" do


### PR DESCRIPTION
This utilizes the consistent `:errors` change in Cog and ensures that all errors are capable of being retrieved using `format_error`. 

These changes should also be cherrypicked into the HEAD and other "stop-gaps" when updating cogctl to use the CogAPI.

We will use this rev in Cogctl until we move to the next changelog updates.

Fixes https://github.com/operable/cog/issues/442