### PR TITLE
Merge update params into existing record

### DIFF
--- a/lib/cog_api/fake/server.ex
+++ b/lib/cog_api/fake/server.ex
@@ -46,8 +46,7 @@ defmodule CogApi.Fake.Server do
   def update(resource_name, id, new_resource) do
     Agent.get_and_update(__MODULE__, fn server ->
       Map.get_and_update(server, resource_name, fn list ->
-        new_list = update_by_id(list, id, new_resource)
-        {new_resource, new_list}
+        update_by_id(list, id, new_resource)
       end)
     end)
   end
@@ -60,9 +59,12 @@ defmodule CogApi.Fake.Server do
     end)
   end
 
-  defp update_by_id(list, id, new_resource) do
+  defp update_by_id(list, id, params) do
     index = Enum.find_index(list, fn resource -> resource.id == id end)
-    List.replace_at(list, index, new_resource)
+    old_resource = Enum.at(list, index)
+    new_resource = Map.merge(old_resource, params)
+    new_list = List.replace_at(list, index, new_resource)
+    {new_resource, new_list}
   end
 
   defp delete_by_id(list, id) do

--- a/test/unit/cog_api/fake/users_test.exs
+++ b/test/unit/cog_api/fake/users_test.exs
@@ -74,19 +74,20 @@ defmodule CogApi.Fake.UsersTest do
 
   describe "update" do
     it "returns the updated user" do
-      params = %{
+      original_params = %{
         first_name: "Arnold",
         last_name: "Vinick",
         email_address: "arnold@example.com",
         username: "arnie",
         password: "12345",
       }
-      new_user = Client.user_create(fake_endpoint, params) |> get_value
+      new_user = Client.user_create(fake_endpoint, original_params) |> get_value
 
-      params = %{first_name: "Arnie"}
-      updated_user = Client.user_update(fake_endpoint, new_user.id, params) |> get_value
+      update_params = %{first_name: "Arnie"}
+      updated_user = Client.user_update(fake_endpoint, new_user.id, update_params) |> get_value
 
-      assert updated_user.first_name == params.first_name
+      assert updated_user.first_name == update_params.first_name
+      assert updated_user.last_name == original_params.last_name
     end
   end
 


### PR DESCRIPTION
Previously, updated models would replace the entire record, which isn't the desired behavior for partial updates.