### PR TITLE
Clean up the `Base` module

### DIFF
--- a/lib/cog_api/http/api_response.ex
+++ b/lib/cog_api/http/api_response.ex
@@ -1,0 +1,87 @@
+defmodule CogApi.HTTP.ApiResponse do
+  alias HTTPotion.Response
+
+  @no_content 204
+  @forbidden 403
+  @unprocessable 422
+
+  @error_codes [@forbidden, @unprocessable]
+
+  def format(response, struct_map \\ nil)
+
+  def format({:error, error_message}, _) do
+    format_error(error_message)
+  end
+
+  def format(%Response{status_code: @no_content}, _), do: :ok
+  def format(response = %Response{status_code: code}, _) when code in @error_codes do
+    format_error(response)
+  end
+
+  def format(response = %Response{}, struct_map) when is_nil(struct_map) do
+    {
+      type(response),
+      Poison.decode!(response.body)
+    }
+  end
+
+  def format(response = %Response{}, struct_map) do
+    {
+      type(response),
+      parse_struct(response, struct_map)
+    }
+  end
+
+  def parse_struct(response, struct_map) do
+    resource = struct_map |> Map.keys |> List.first
+    Poison.decode!(response.body, as: struct_map)[resource]
+  end
+
+  defp format_error(response=%Response{}) do
+    errors = response.body
+    |> Poison.decode!
+    |> extract_errors
+    |> parse_errors
+
+    {:error, errors}
+  end
+  defp format_error(error_message) do
+    {
+      :error,
+      parse_errors(error_message)
+    }
+  end
+
+  defp extract_errors(%{"errors" => errors}), do: errors
+  defp extract_errors(%{"error" => error}), do: [error]
+
+  defp parse_errors(errors = %{}) do
+    Enum.flat_map errors, fn {key, values} ->
+      key = String.replace(key, "_", " ") |> String.capitalize
+
+      Enum.map values, fn value ->
+        "#{key} #{value}"
+      end
+    end
+  end
+  defp parse_errors(errors) when is_list(errors), do: errors
+  defp parse_errors(errors) when is_binary(errors) do
+    [errors]
+  end
+
+  def type(%HTTPotion.Response{} = response) do
+    if HTTPotion.Response.success?(response) do
+      :ok
+    else
+      :error
+    end
+  end
+
+  def type(responses) do
+    if Enum.all?(responses, fn(response) -> response == :ok end) do
+      :ok
+    else
+      :error
+    end
+  end
+end

--- a/lib/cog_api/http/authentication.ex
+++ b/lib/cog_api/http/authentication.ex
@@ -2,12 +2,13 @@ defmodule CogApi.HTTP.Authentication do
   import CogApi.HTTP.Base
 
   alias CogApi.Endpoint
+  alias CogApi.HTTP.ApiResponse
 
   def get_and_merge_token(%Endpoint{token: nil}=endpoint) do
     params = %{username: endpoint.username, password: endpoint.password}
 
     post(endpoint, "token", params)
-    |> format_generic_response
+    |> ApiResponse.format
     |> merge_token(endpoint)
   end
 

--- a/lib/cog_api/http/bundles.ex
+++ b/lib/cog_api/http/bundles.ex
@@ -1,4 +1,5 @@
 defmodule CogApi.HTTP.Bundles do
+  alias CogApi.HTTP.ApiResponse
   alias CogApi.HTTP.Base
 
   alias CogApi.Endpoint
@@ -6,12 +7,12 @@ defmodule CogApi.HTTP.Bundles do
 
   def index(%Endpoint{}=endpoint) do
     Base.get(endpoint, "bundles")
-    |> Base.format_response("bundles", [%Bundle{}])
+    |> ApiResponse.format(%{"bundles" => [%Bundle{}]})
   end
 
   def show(%Endpoint{}=endpoint, id) do
     Base.get(endpoint, "bundles/#{id}")
-    |> Base.format_response("bundle", %Bundle{})
+    |> ApiResponse.format(%{"bundle" => %Bundle{}})
   end
 
   def update(%Endpoint{}=endpoint, bundle_id, %{enabled: enabled}) do
@@ -23,7 +24,7 @@ defmodule CogApi.HTTP.Bundles do
 
   defp format_update_response(response, bundle_id) do
     {
-      Base.response_type(response),
+      ApiResponse.type(response),
       build_bundle_struct(Poison.decode!(response.body), bundle_id)
     }
   end

--- a/lib/cog_api/http/groups.ex
+++ b/lib/cog_api/http/groups.ex
@@ -1,4 +1,5 @@
 defmodule CogApi.HTTP.Groups do
+  alias CogApi.HTTP.ApiResponse
   alias CogApi.HTTP.Base
   alias HTTPotion.Response
 
@@ -7,7 +8,8 @@ defmodule CogApi.HTTP.Groups do
   alias CogApi.Resources.User
 
   def index(%Endpoint{}=endpoint) do
-    Base.get(endpoint, "groups") |> Base.format_response("groups", [%Group{}])
+    Base.get(endpoint, "groups")
+    |> ApiResponse.format(%{"groups" => [%Group{}]})
   end
 
   def show(%Endpoint{}=endpoint, id) do
@@ -20,7 +22,7 @@ defmodule CogApi.HTTP.Groups do
     {users_status, users} = group_json |> List.last |> Task.await
 
     {
-      Base.response_type([group_status, users_status]),
+      ApiResponse.type([group_status, users_status]),
       %{group | users: users}
     }
   end
@@ -30,19 +32,19 @@ defmodule CogApi.HTTP.Groups do
     json_map = %{"members" => %{"users" => [%User{}]}}
     users = Poison.decode!(response.body, as: json_map)["members"]["users"]
     {
-      Base.response_type(response),
+      ApiResponse.type(response),
       users
     }
   end
 
   defp get_group(endpoint, id) do
     Base.get(endpoint, "groups/#{id}")
-    |> Base.format_response("group", %Group{})
+    |> ApiResponse.format(%{"group" => %Group{}})
   end
 
   def create(%Endpoint{}=endpoint, params) do
     Base.post(endpoint, "groups", %{group: params})
-    |> Base.format_response("group", %Group{})
+    |> ApiResponse.format(%{"group" => %Group{}})
   end
 
   def delete(%Endpoint{}=endpoint, group_id) do
@@ -68,7 +70,7 @@ defmodule CogApi.HTTP.Groups do
     json_map = %{"members" => %{"users" => [%User{}]}}
     body = Poison.decode!(response.body, as: json_map)
     {
-      Base.response_type(response),
+      ApiResponse.type(response),
       %{group | users: body["members"]["users"] }
     }
   end

--- a/lib/cog_api/http/permissions.ex
+++ b/lib/cog_api/http/permissions.ex
@@ -1,15 +1,16 @@
 defmodule CogApi.HTTP.Permissions do
   alias CogApi.Endpoint
+  alias CogApi.HTTP.ApiResponse
   alias CogApi.HTTP.Base
   alias CogApi.Resources.Permission
 
   def index(%Endpoint{}=endpoint) do
     Base.get(endpoint, "permissions")
-    |> Base.format_response("permissions", [%Permission{}])
+    |> ApiResponse.format(%{"permissions" => [%Permission{}]})
   end
 
   def create(%Endpoint{}=endpoint, name) do
     Base.post(endpoint, "permissions", %{"permission" => %{"name" => name}})
-    |> Base.format_response("permission", %Permission{})
+    |> ApiResponse.format(%{"permission" => %Permission{}})
   end
 end

--- a/lib/cog_api/http/roles.ex
+++ b/lib/cog_api/http/roles.ex
@@ -1,28 +1,32 @@
 defmodule CogApi.HTTP.Roles do
   alias CogApi.Endpoint
+  alias CogApi.HTTP.ApiResponse
   alias CogApi.HTTP.Base
   alias CogApi.Resources.Role
 
   def index(%Endpoint{}=endpoint) do
-    Base.get(endpoint, "roles") |> Base.format_response("roles", [%Role{}])
+    Base.get(endpoint, "roles")
+    |> ApiResponse.format(%{"roles" => [%Role{}]})
   end
 
   def show(%Endpoint{}=endpoint, id) do
-    Base.get(endpoint, "roles/#{id}") |> Base.format_response("role", %Role{})
+    Base.get(endpoint, "roles/#{id}")
+    |> ApiResponse.format(%{"role" => %Role{}})
   end
 
   def create(%Endpoint{}=endpoint, params) do
     Base.post(endpoint, "roles", %{"role" => params})
-    |> Base.format_response("role", %Role{})
+    |> ApiResponse.format(%{"role" => %Role{}})
   end
 
   def update(%Endpoint{}=endpoint, role_id, params) do
     Base.patch(endpoint, "roles/#{role_id}", %{"role" => params})
-    |> Base.format_response("role", %Role{})
+    |> ApiResponse.format(%{"role" => %Role{}})
   end
 
   def delete(%Endpoint{}=endpoint, role_id) do
-    Base.delete(endpoint, "roles/#{role_id}") |> Base.format_response("role", %Role{})
+    Base.delete(endpoint, "roles/#{role_id}")
+    |> ApiResponse.format(%{"role" => %Role{}})
   end
 
   def grant(%Endpoint{}=endpoint, role, group) do
@@ -40,10 +44,10 @@ defmodule CogApi.HTTP.Roles do
   end
 
   defp format_response(response, group) do
-    body = Poison.decode!(response.body, as: %{"roles" => [%Role{}]})
+    roles = ApiResponse.parse_struct(response,  %{"roles" => [%Role{}]})
     {
-      Base.response_type(response),
-      %{group | roles: body["roles"] }
+      ApiResponse.type(response),
+      %{group | roles: roles }
     }
   end
 end

--- a/lib/cog_api/http/users.ex
+++ b/lib/cog_api/http/users.ex
@@ -1,30 +1,32 @@
 defmodule CogApi.HTTP.Users do
+  alias CogApi.HTTP.ApiResponse
   alias CogApi.HTTP.Base
 
   alias CogApi.Endpoint
   alias CogApi.Resources.User
 
   def index(%Endpoint{}=endpoint) do
-    Base.get(endpoint, "users") |> Base.format_response("users", [%User{}])
+    Base.get(endpoint, "users")
+    |> ApiResponse.format(%{"users" => [%User{}]})
   end
 
   def show(%Endpoint{}=endpoint, id) do
     Base.get(endpoint, "users/#{id}")
-    |> Base.format_response("user", %User{})
+    |> ApiResponse.format(%{"user" => %User{}})
   end
 
   def create(%Endpoint{}=endpoint, params) do
     Base.post(endpoint, "users", %{user: params})
-    |> Base.format_response("user", %User{})
+    |> ApiResponse.format(%{"user" => %User{}})
   end
 
   def update(%Endpoint{}=endpoint, id, params) do
     Base.patch(endpoint, "users/#{id}", %{"user" => params})
-    |> Base.format_response("user", %User{})
+    |> ApiResponse.format(%{"user" => %User{}})
   end
 
   def delete(%Endpoint{}=endpoint, id) do
     Base.delete(endpoint, "users/#{id}")
-    |> Base.format_response("user", %User{})
+    |> ApiResponse.format(%{"user" => %User{}})
   end
 end


### PR DESCRIPTION
* Extract the format responses into another module and rename
* Rename the functions based on the module name
* Pass in a map instead of two params.
* Remove the `generic_` functions and allow switching based on the presence of a struct map
* Expose a function directly for parsing the response with a struct