### PR TITLE
Ensure that the Fake bundle performs as the HTTP

### DIFF
--- a/lib/cog_api/fake/bundles.ex
+++ b/lib/cog_api/fake/bundles.ex
@@ -26,7 +26,7 @@ defmodule CogApi.Fake.Bundles do
   def update(%Endpoint{token: _}, id, %{enabled: enabled} = params) do
     catch_errors params, fn ->
       current_bundle = Server.show(:bundles, id)
-      updated_bundle = %{current_bundle | enabled: enabled}
+      updated_bundle = %{current_bundle | enabled: ensure_bundle_encode_status(enabled)}
 
       {:ok, Server.update(:bundles, id, updated_bundle)}
     end
@@ -34,5 +34,10 @@ defmodule CogApi.Fake.Bundles do
 
   def update(%Endpoint{token: _}, _, %{}) do
     {:error, "You can only enable or disable a bundle"}
+  end
+
+  defp ensure_bundle_encode_status(status) do
+    Bundle.encode_status(status)
+    status == "true"
   end
 end

--- a/lib/cog_api/resources/bundle.ex
+++ b/lib/cog_api/resources/bundle.ex
@@ -12,6 +12,7 @@ defmodule CogApi.Resources.Bundle do
   def decode_status("enabled"), do: true
   def decode_status("disabled"), do: false
 
+  def encode_status("true"), do: "enabled"
   def encode_status(true), do: "enabled"
-  def encode_status(false), do: "disabled"
+  def encode_status(_), do: "disabled"
 end

--- a/test/unit/cog_api/fake/bundles_test.exs
+++ b/test/unit/cog_api/fake/bundles_test.exs
@@ -63,6 +63,18 @@ defmodule CogApi.Fake.BundlesTest do
       assert updated_bundle.enabled == false
     end
 
+    it "will allow a string for enabled" do
+      bundle = %Bundle{name: "a bundle", enabled: true}
+      bundle = Client.bundle_create(fake_endpoint, bundle) |> get_value
+
+      {:ok, updated_bundle} = Client.bundle_update(
+        fake_endpoint,
+        bundle.id,
+        %{enabled: "false"}
+      )
+      assert updated_bundle.enabled == false
+    end
+
     it "only updates the enabled attribute" do
       bundle = %Bundle{id: "id123", name: "a bundle", enabled: true}
       Server.create(:bundles, bundle)


### PR DESCRIPTION
`HTTP.Bundle` runs `Bundle.encode_status`
which did not accept a string.
This meant that if you passed a string,
the fake would work fine,
but `HTTP.Bundle` would throw an exception.
This ensures that we use the same function
so the fake would have blown up as well.
It also coerces the string into a boolean.