### PR TITLE
Don't include default values in resource structs

### DIFF
--- a/lib/cog_api/http/bundles.ex
+++ b/lib/cog_api/http/bundles.ex
@@ -8,7 +8,7 @@ defmodule CogApi.HTTP.Bundles do
 
   def index(%Endpoint{}=endpoint) do
     Base.get(endpoint, "bundles")
-    |> ApiResponse.format(%{"bundles" => [%Bundle{}]})
+    |> ApiResponse.format(%{"bundles" => [Bundle.format]})
   end
 
   def show(%Endpoint{}=endpoint, id) do
@@ -25,7 +25,7 @@ defmodule CogApi.HTTP.Bundles do
 
   defp find_bundle(endpoint, id) do
     Base.get(endpoint, "bundles/#{id}")
-    |> ApiResponse.format(%{"bundle" => %Bundle{}})
+    |> ApiResponse.format(%{"bundle" => Bundle.format})
   end
 
   defp add_rules(endpoint, bundle) do

--- a/lib/cog_api/http/relay_groups.ex
+++ b/lib/cog_api/http/relay_groups.ex
@@ -7,22 +7,22 @@ defmodule CogApi.HTTP.RelayGroups do
 
   def index(%Endpoint{}=endpoint) do
     Base.get(endpoint, "relay_groups")
-    |> ApiResponse.format(%{"relay_groups" => [%RelayGroup{}]})
+    |> ApiResponse.format(%{"relay_groups" => [RelayGroup.format]})
   end
 
   def show(id, %Endpoint{}=endpoint) do
     Base.get(endpoint, resource_path(id))
-    |> ApiResponse.format(%{"relay_group" => %RelayGroup{}})
+    |> ApiResponse.format(%{"relay_group" => RelayGroup.format})
   end
 
   def create(params, %Endpoint{}=endpoint) do
     Base.post(endpoint, "relay_groups", %{relay_group: params})
-    |> ApiResponse.format(%{"relay_group" => %RelayGroup{}})
+    |> ApiResponse.format(%{"relay_group" => RelayGroup.format})
   end
 
   def update(id, params, %Endpoint{}=endpoint) do
     Base.patch(endpoint, resource_path(id), %{relay_group: params})
-    |> ApiResponse.format(%{"relay_group" => %RelayGroup{}})
+    |> ApiResponse.format(%{"relay_group" => RelayGroup.format})
   end
 
   def delete(id, %Endpoint{}=endpoint) do
@@ -41,7 +41,7 @@ defmodule CogApi.HTTP.RelayGroups do
   defp update_membership(relay_group_id, relay_id, action, endpoint) do
     path = "relay_groups/#{relay_group_id}/membership"
     Base.post(endpoint, path, %{relays: %{action =>  [relay_id]}})
-    |> ApiResponse.format(%{"relay_group" => %RelayGroup{}})
+    |> ApiResponse.format(%{"relay_group" => RelayGroup.format})
   end
 
   defp resource_path(id) do

--- a/lib/cog_api/http/roles.ex
+++ b/lib/cog_api/http/roles.ex
@@ -6,31 +6,31 @@ defmodule CogApi.HTTP.Roles do
 
   def index(%Endpoint{}=endpoint) do
     Base.get(endpoint, "roles")
-    |> ApiResponse.format(%{"roles" => [%Role{}]})
+    |> ApiResponse.format(%{"roles" => [Role.format]})
   end
 
   def show(%Endpoint{}=endpoint, %{name: role_name}) do
     Base.get_by(endpoint, "roles", name: role_name)
-    |> ApiResponse.format(%{"role" => %Role{}})
+    |> ApiResponse.format(%{"role" => Role.format})
   end
   def show(%Endpoint{}=endpoint, id) do
     Base.get(endpoint, "roles/#{id}")
-    |> ApiResponse.format(%{"role" => %Role{}})
+    |> ApiResponse.format(%{"role" => Role.format})
   end
 
   def create(%Endpoint{}=endpoint, params) do
     Base.post(endpoint, "roles", %{"role" => params})
-    |> ApiResponse.format(%{"role" => %Role{}})
+    |> ApiResponse.format(%{"role" => Role.format})
   end
 
   def update(%Endpoint{}=endpoint, role_id, params) do
     Base.patch(endpoint, "roles/#{role_id}", %{"role" => params})
-    |> ApiResponse.format(%{"role" => %Role{}})
+    |> ApiResponse.format(%{"role" => Role.format})
   end
 
   def delete(%Endpoint{}=endpoint, role_id) do
     Base.delete(endpoint, "roles/#{role_id}")
-    |> ApiResponse.format(%{"role" => %Role{}})
+    |> ApiResponse.format(%{"role" => Role.format})
   end
 
   def grant(%Endpoint{}=endpoint, role, group) do
@@ -48,7 +48,7 @@ defmodule CogApi.HTTP.Roles do
   end
 
   defp format_response(response, group) do
-    roles = ApiResponse.parse_struct(response,  %{"roles" => [%Role{}]})
+    roles = ApiResponse.parse_struct(response,  %{"roles" => [Role.format]})
     {
       ApiResponse.type(response),
       %{group | roles: roles }

--- a/lib/cog_api/http/users.ex
+++ b/lib/cog_api/http/users.ex
@@ -7,26 +7,26 @@ defmodule CogApi.HTTP.Users do
 
   def index(%Endpoint{}=endpoint) do
     Base.get(endpoint, "users")
-    |> ApiResponse.format(%{"users" => [%User{}]})
+    |> ApiResponse.format(%{"users" => [User.format]})
   end
 
   def show(%Endpoint{}=endpoint, id) do
     Base.get(endpoint, "users/#{id}")
-    |> ApiResponse.format(%{"user" => %User{}})
+    |> ApiResponse.format(%{"user" => User.format})
   end
 
   def create(%Endpoint{}=endpoint, params) do
     Base.post(endpoint, "users", %{user: params})
-    |> ApiResponse.format(%{"user" => %User{}})
+    |> ApiResponse.format(%{"user" => User.format})
   end
 
   def update(%Endpoint{}=endpoint, id, params) do
     Base.patch(endpoint, "users/#{id}", %{"user" => params})
-    |> ApiResponse.format(%{"user" => %User{}})
+    |> ApiResponse.format(%{"user" => User.format})
   end
 
   def delete(%Endpoint{}=endpoint, id) do
     Base.delete(endpoint, "users/#{id}")
-    |> ApiResponse.format(%{"user" => %User{}})
+    |> ApiResponse.format(%{"user" => User.format})
   end
 end

--- a/lib/cog_api/resources/bundle.ex
+++ b/lib/cog_api/resources/bundle.ex
@@ -7,7 +7,7 @@ defmodule CogApi.Resources.Bundle do
     :name,
     :inserted_at,
     :updated_at,
-    commands: [%CogApi.Resources.Command{}],
+    commands: [],
   ]
 
   def decode_status("enabled"), do: true
@@ -16,4 +16,10 @@ defmodule CogApi.Resources.Bundle do
   def encode_status("true"), do: "enabled"
   def encode_status(true), do: "enabled"
   def encode_status(_), do: "disabled"
+
+  def format do
+    %__MODULE__{
+      commands: [%CogApi.Resources.Command{}],
+    }
+  end
 end

--- a/lib/cog_api/resources/group.ex
+++ b/lib/cog_api/resources/group.ex
@@ -7,4 +7,11 @@ defmodule CogApi.Resources.Group do
     roles: [],
     users: [],
   ]
+
+  def format do
+    %__MODULE__{
+      roles: [%CogApi.Resources.Role{}],
+      users: [%CogApi.Resources.User{}],
+    }
+  end
 end

--- a/lib/cog_api/resources/relay_group.ex
+++ b/lib/cog_api/resources/relay_group.ex
@@ -7,6 +7,13 @@ defmodule CogApi.Resources.RelayGroup do
     :updated_at,
     :inserted_at,
     bundles: [],
-    relays: [%CogApi.Resources.Relay{}],
+    relays: [],
   ]
+
+  def format do
+    %__MODULE__{
+      bundles: [%CogApi.Resources.Bundle{}],
+      relays: [%CogApi.Resources.Relay{}],
+    }
+  end
 end

--- a/lib/cog_api/resources/role.ex
+++ b/lib/cog_api/resources/role.ex
@@ -4,6 +4,12 @@ defmodule CogApi.Resources.Role do
   defstruct [
     :id,
     :name,
-    permissions: [%CogApi.Resources.Permission{}],
+    permissions: [],
   ]
+
+  def format do
+    %__MODULE__{
+      permissions: [%CogApi.Resources.Permission{}],
+    }
+  end
 end

--- a/lib/cog_api/resources/user.ex
+++ b/lib/cog_api/resources/user.ex
@@ -9,4 +9,10 @@ defmodule CogApi.Resources.User do
     :username,
     groups: [],
   ]
+
+  def format do
+    %__MODULE__{
+      groups: [%CogApi.Resources.Group{}],
+    }
+  end
 end


### PR DESCRIPTION
We were using default values to tell Poison how to parse associated
resources. This meant that anytime we didn't explicitly set those values
we would get a blank associated record. This fixes that by using another
function to instantiate a record for Poison to match against.