### PR TITLE
if format_response receives an error tuple, just return it

### DIFF
--- a/lib/cog_api/http/groups.ex
+++ b/lib/cog_api/http/groups.ex
@@ -50,6 +50,10 @@ defmodule CogApi.HTTP.Groups do
     |> format_group_response
   end
 
+  defp format_group_response({:error, _}=response) do
+    response
+  end
+
   defp format_group_response(response) do
     json_structure = %{"group" => GroupDecoder.format}
     groups = Poison.decode!(response.body, as: json_structure)["group"]

--- a/test/fixtures/vcr/group_find_error.json
+++ b/test/fixtures/vcr/group_find_error.json
@@ -1,0 +1,53 @@
+[
+  {
+    "request": {
+      "body": "{\"username\":\"admin\",\"password\":\"password\"}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/token"
+    },
+    "response": {
+      "body": "{\"token\":{\"value\":\"6UwpBsiLJx3CzUQsYKgXLwUTuZOSUFX4BoAuvi5dnm4=\"}}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 05 Apr 2016 18:55:51 GMT",
+        "content-length": "66",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "b2v5m30d8mluuevkfank6sjj13gs0jsf"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "token 6UwpBsiLJx3CzUQsYKgXLwUTuZOSUFX4BoAuvi5dnm4=",
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/groups"
+    },
+    "response": {
+      "body": "{\"groups\":[]}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 05 Apr 2016 18:55:51 GMT",
+        "content-length": "13",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "no1von0ctkci0j11m5enaveqkueh05kn"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/unit/cog_api/http/groups_test.exs
+++ b/test/unit/cog_api/http/groups_test.exs
@@ -55,6 +55,15 @@ defmodule CogApi.HTTP.GroupsTest do
         end
       end
     end
+
+    context "when the group does not exist" do
+      it "returns an error tuple" do
+        cassette "group_find_error" do
+          response = Client.group_find(valid_endpoint, name: "lolwut")
+          assert {:error, _} = response
+        end
+      end
+    end
   end
 
   describe "group_create" do


### PR DESCRIPTION
Very quick fix to return errors instead of blowing up if format_group_response gets an error tuple instead of a group back. This can happen in `get_by`. 

cc: @drapergeek @jsteiner 