### PR TITLE
Store relationships as references instead of full objects

### DIFF
--- a/lib/cog_api/fake/bundles.ex
+++ b/lib/cog_api/fake/bundles.ex
@@ -9,12 +9,12 @@ defmodule CogApi.Fake.Bundles do
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(:bundles)}
+    {:ok, Server.index(Bundle.fake_server_information)}
   end
 
   def show(%Endpoint{token: nil}, _),  do: Endpoint.invalid_endpoint
   def show(%Endpoint{}=endpoint, id) do
-    bundle = Server.show(:bundles, id)
+    bundle = Server.show(Bundle.fake_server_information, id)
     bundle = %{bundle | commands: add_rules(endpoint, bundle)}
     {:ok, bundle}
   end
@@ -34,22 +34,22 @@ defmodule CogApi.Fake.Bundles do
   def create(%Endpoint{token: _}, params) do
     new_bundle = %Bundle{id: random_string(8)}
     new_bundle = Map.merge(new_bundle, params)
-    {:ok, Server.create(:bundles, new_bundle)}
+    {:ok, Server.create(Bundle.fake_server_information, new_bundle)}
   end
 
   def update(%Endpoint{token: _}, %{name: name}, %{enabled: enabled} = params) do
     catch_errors params, fn ->
-      current_bundle = Server.show_by_key(:bundles, :name, name)
+      current_bundle = Server.show_by_key(Bundle.fake_server_information, :name, name)
       updated_bundle = %{current_bundle | enabled: ensure_bundle_encode_status(enabled)}
-      {:ok, Server.update(:bundles, current_bundle.id, updated_bundle)}
+      {:ok, Server.update(Bundle.fake_server_information, current_bundle.id, updated_bundle)}
     end
   end
   def update(%Endpoint{token: _}, id, %{enabled: enabled} = params) do
     catch_errors params, fn ->
-      current_bundle = Server.show(:bundles, id)
+      current_bundle = Server.show(Bundle.fake_server_information, id)
       updated_bundle = %{current_bundle | enabled: ensure_bundle_encode_status(enabled)}
 
-      {:ok, Server.update(:bundles, id, updated_bundle)}
+      {:ok, Server.update(Bundle.fake_server_information, id, updated_bundle)}
     end
   end
 
@@ -59,8 +59,8 @@ defmodule CogApi.Fake.Bundles do
 
   def delete(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id) do
-    if Server.show(:bundles, id) do
-      Server.delete(:bundles, id)
+    if Server.show(Bundle.fake_server_information, id) do
+      Server.delete(Bundle.fake_server_information, id)
       :ok
     else
       {:error, ["The bundle could not be deleted"]}

--- a/lib/cog_api/fake/groups.ex
+++ b/lib/cog_api/fake/groups.ex
@@ -5,20 +5,21 @@ defmodule CogApi.Fake.Groups do
   alias CogApi.Endpoint
   alias CogApi.Fake.Server
   alias CogApi.Resources.Group
+  alias CogApi.Resources.User
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(:groups)}
+    {:ok, Server.index(Group.fake_server_information)}
   end
 
   def show(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def show(%Endpoint{token: _}, id) do
-    {:ok, Server.show(:groups, id)}
+    {:ok, Server.show(Group.fake_server_information, id)}
   end
 
   def find(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def find(%Endpoint{token: _}, params) do
-    groups = Server.index(:groups)
+    groups = Server.index(Group.fake_server_information)
     case Enum.find(groups, &(&1.name == params[:name])) do
       nil ->
         {:error, "Group not found"}
@@ -30,20 +31,20 @@ defmodule CogApi.Fake.Groups do
   def create(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def create(%Endpoint{token: _}, %{name: name}) do
     new_group = %Group{id: random_string(8), name: name}
-    {:ok, Server.create(:groups, new_group)}
+    {:ok, Server.create(Group.fake_server_information, new_group)}
   end
 
   def update(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def update(%Endpoint{token: _}, id, %{name: _name}=params) do
     catch_errors params, fn ->
-      {:ok, Server.update(:groups, id, params)}
+      {:ok, Server.update(Group.fake_server_information, id, params)}
     end
   end
 
   def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id) do
-    if Server.show(:groups, id) do
-      Server.delete(:groups, id)
+    if Server.show(Group.fake_server_information, id) do
+      Server.delete(Group.fake_server_information, id)
       :ok
     else
       {:error, ["The group could not be deleted"]}
@@ -51,21 +52,22 @@ defmodule CogApi.Fake.Groups do
   end
 
   def add_user(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
-  def add_user(%Endpoint{token: _}, group, user) do    user = Server.show_by_key(:users, :email_address, user.email_address)
-    group = Server.show(:groups, group.id)
+  def add_user(%Endpoint{token: _}, group, user) do
+    user = Server.show_by_key(User.fake_server_information, :email_address, user.email_address)
+    group = Server.show(Group.fake_server_information, group.id)
     users = group.users ++ [user]
     group = %{group | users: users}
 
-    {:ok, Server.update(:groups, group.id, group)}
+    {:ok, Server.update(Group.fake_server_information, group.id, group)}
   end
 
   def remove_user(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def remove_user(%Endpoint{token: _}, group, user) do
-    user = Server.show_by_key(:users, :email_address, user.email_address)
-    group = Server.show(:groups, group.id)
+    user = Server.show_by_key(User.fake_server_information, :email_address, user.email_address)
+    group = Server.show(Group.fake_server_information, group.id)
     users = group.users -- [user]
     group = %{group | users: users}
 
-    {:ok, Server.update(:groups, group.id, group)}
+    {:ok, Server.update(Group.fake_server_information, group.id, group)}
   end
 end

--- a/lib/cog_api/fake/permissions.ex
+++ b/lib/cog_api/fake/permissions.ex
@@ -8,7 +8,7 @@ defmodule CogApi.Fake.Permissions do
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(:permissions)}
+    {:ok, Server.index(Permission.fake_server_information)}
   end
 
   def create(%Endpoint{token: nil}, %{name: _}), do: Endpoint.invalid_endpoint
@@ -21,7 +21,7 @@ defmodule CogApi.Fake.Permissions do
       namespace: %Namespace{id: random_string(8), name: namespace},
     }
 
-    {:ok, Server.create(:permissions, new_permission)}
+    {:ok, Server.create(Permission.fake_server_information, new_permission)}
   end
 
   defp build_namespaced_name(name) do

--- a/lib/cog_api/fake/relay_groups.ex
+++ b/lib/cog_api/fake/relay_groups.ex
@@ -3,33 +3,34 @@ defmodule CogApi.Fake.RelayGroups do
 
   alias CogApi.Endpoint
   alias CogApi.Fake.Server
+  alias CogApi.Resources.Relay
   alias CogApi.Resources.RelayGroup
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(:relay_groups)}
+    {:ok, Server.index(RelayGroup.fake_server_information)}
   end
 
   def show(_, %Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def show(id, %Endpoint{}) do
-    {:ok, Server.show(:relay_groups, id)}
+    {:ok, Server.show(RelayGroup.fake_server_information, id)}
   end
 
   def create(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def create(%{name: name}, %Endpoint{token: _}) do
     new_relay_group = %RelayGroup{id: random_string(8), name: name, relays: []}
-    {:ok, Server.create(:relay_groups, new_relay_group)}
+    {:ok, Server.create(RelayGroup.fake_server_information, new_relay_group)}
   end
 
   def update(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def update(id, params, %Endpoint{token: _}) do
-    {:ok, Server.update(:relay_groups, id, params)}
+    {:ok, Server.update(RelayGroup.fake_server_information, id, params)}
   end
 
   def delete(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def delete(id, %Endpoint{token: _}) do
-    if Server.show(:relay_groups, id) do
-      Server.delete(:relay_groups, id)
+    if Server.show(RelayGroup.fake_server_information, id) do
+      Server.delete(RelayGroup.fake_server_information, id)
       :ok
     else
       {:error, ["The relay group could not be deleted"]}
@@ -38,27 +39,27 @@ defmodule CogApi.Fake.RelayGroups do
 
   def add_relay(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def add_relay(id, relay_id, %Endpoint{token: _}) do
-    relay = Server.show(:relays, relay_id)
-    relay_group = Server.show(:relay_groups, id)
+    relay = Server.show(Relay.fake_server_information, relay_id)
+    relay_group = Server.show(RelayGroup.fake_server_information, id)
     relay_with_group = %{relay | groups: relay.groups ++ [relay_group]}
-    Server.update(:relays, relay.id, relay_with_group)
+    Server.update(Relay.fake_server_information, relay.id, relay_with_group)
 
     relays = relay_group.relays ++ [relay_with_group]
     relay_group = %{relay_group | relays: relays}
 
-    {:ok, Server.update(:relay_groups, id, relay_group)}
+    {:ok, Server.update(RelayGroup.fake_server_information, id, relay_group)}
   end
 
   def remove_relay(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def remove_relay(id, relay_id, %Endpoint{token: _}) do
-    relay = Server.show(:relays, relay_id)
-    relay_group = Server.show(:relay_groups, id)
+    relay = Server.show(Relay.fake_server_information, relay_id)
+    relay_group = Server.show(RelayGroup.fake_server_information, id)
     relays = relay_group.relays -- [relay]
     relay_group = %{relay_group | relays: relays}
 
     relay_without_group = %{relay | groups: relay.groups -- [relay_group]}
-    Server.update(:relays, relay.id, relay_without_group)
+    Server.update(Relay.fake_server_information, relay.id, relay_without_group)
 
-    {:ok, Server.update(:relay_groups, id, relay_group)}
+    {:ok, Server.update(RelayGroup.fake_server_information, id, relay_group)}
   end
 end

--- a/lib/cog_api/fake/relays.ex
+++ b/lib/cog_api/fake/relays.ex
@@ -8,12 +8,12 @@ defmodule CogApi.Fake.Relays do
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(:relays)}
+    {:ok, Server.index(Relay.fake_server_information)}
   end
 
   def show(_, %Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def show(id, %Endpoint{}) do
-    {:ok, Server.show(:relays, id)}
+    {:ok, Server.show(Relay.fake_server_information, id)}
   end
 
   def create(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
@@ -21,21 +21,21 @@ defmodule CogApi.Fake.Relays do
     catch_errors params, fn ->
       new_relay = %Relay{id: random_string(8)}
       new_relay = Map.merge(new_relay, params)
-      {:ok, Server.create(:relays, new_relay)}
+      {:ok, Server.create(Relay.fake_server_information, new_relay)}
     end
   end
 
   def update(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def update(id, params, %Endpoint{token: _}) do
     catch_errors params, fn ->
-      {:ok, Server.update(:relays, id, params)}
+      {:ok, Server.update(Relay.fake_server_information, id, params)}
     end
   end
 
   def delete(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def delete(id, %Endpoint{token: _}) do
-    if Server.show(:relays, id) do
-      Server.delete(:relays, id)
+    if Server.show(Relay.fake_server_information, id) do
+      Server.delete(Relay.fake_server_information, id)
       :ok
     else
       {:error, ["The relay could not be deleted"]}

--- a/lib/cog_api/fake/roles.ex
+++ b/lib/cog_api/fake/roles.ex
@@ -3,47 +3,48 @@ defmodule CogApi.Fake.Roles do
 
   alias CogApi.Endpoint
   alias CogApi.Fake.Server
+  alias CogApi.Resources.Group
   alias CogApi.Resources.Role
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(:roles)}
+    {:ok, Server.index(Role.fake_server_information)}
   end
 
   def show(%Endpoint{token: nil}, _),  do: Endpoint.invalid_endpoint
   def show(%Endpoint{}, %{name: name}) do
-    {:ok, Server.show_by_key(:roles, :name, name)}
+    {:ok, Server.show_by_key(Role.fake_server_information, :name, name)}
   end
   def show(%Endpoint{}, id) do
-    {:ok, Server.show(:roles, id)}
+    {:ok, Server.show(Role.fake_server_information, id)}
   end
 
   def create(%Endpoint{token: nil}, %{name: _}), do: Endpoint.invalid_endpoint
   def create(%Endpoint{token: _}, %{name: name}) do
     new_role = %Role{id: random_string(8), name: name}
-    {:ok, Server.create(:roles, new_role)}
+    {:ok, Server.create(Role.fake_server_information, new_role)}
   end
 
   def update(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def update(%Endpoint{token: _}, id, params) do
-    {:ok, Server.update(:roles, id, params)}
+    {:ok, Server.update(Role.fake_server_information, id, params)}
   end
 
   def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id) do
-    Server.delete(:roles, id)
+    Server.delete(Role.fake_server_information, id)
     :ok
   end
 
   def grant(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def grant(%Endpoint{}, role, group) do
     group = %{group | roles: group.roles ++ [role]}
-    {:ok, Server.update(:groups, group.id, group)}
+    {:ok, Server.update(Group.fake_server_information, group.id, group)}
   end
 
   def revoke(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def revoke(%Endpoint{}, role, group) do
     group = %{group | roles: List.delete(group.roles, role)}
-    {:ok, Server.update(:groups, group.id, group)}
+    {:ok, Server.update(Group.fake_server_information, group.id, group)}
   end
 end

--- a/lib/cog_api/fake/rules.ex
+++ b/lib/cog_api/fake/rules.ex
@@ -8,7 +8,7 @@ defmodule CogApi.Fake.Rules do
   def index(_, %Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(command, %Endpoint{}) do
     rules =
-    Server.index(:rules)
+    Server.index(Rule.fake_server_information)
     |> Enum.filter(fn rule -> rule.command == command end)
     {:ok, rules}
   end
@@ -23,14 +23,14 @@ defmodule CogApi.Fake.Rules do
         id: random_string(8),
         rule: rule,
       }
-      {:ok, Server.create(:rules, new_rule)}
+      {:ok, Server.create(Rule.fake_server_information, new_rule)}
     end
   end
 
   def delete(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def delete(id, %Endpoint{token: _}) do
-    if Server.show(:rules, id) do
-      Server.delete(:rules, id)
+    if Server.show(Rule.fake_server_information, id) do
+      Server.delete(Rule.fake_server_information, id)
     else
       {:error, ["The rule could not be deleted"]}
     end

--- a/lib/cog_api/fake/users.ex
+++ b/lib/cog_api/fake/users.ex
@@ -8,12 +8,12 @@ defmodule CogApi.Fake.Users do
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(:users)}
+    {:ok, Server.index(User.fake_server_information)}
   end
 
   def show(%Endpoint{token: nil}, _),  do: Endpoint.invalid_endpoint
   def show(%Endpoint{}, id) do
-    {:ok, Server.show(:users, id)}
+    {:ok, Server.show(User.fake_server_information, id)}
   end
 
   def create(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
@@ -21,20 +21,20 @@ defmodule CogApi.Fake.Users do
     catch_errors params, fn ->
       new_user = %User{id: random_string(8)}
       new_user = Map.merge(new_user, params)
-      {:ok, Server.create(:users, new_user)}
+      {:ok, Server.create(User.fake_server_information, new_user)}
     end
   end
 
   def update(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def update(%Endpoint{token: _}, id, params) do
     catch_errors params, fn ->
-      {:ok, Server.update(:users, id, params)}
+      {:ok, Server.update(User.fake_server_information, id, params)}
     end
   end
 
   def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id) do
-    Server.delete(:users, id)
+    Server.delete(User.fake_server_information, id)
     :ok
   end
 end

--- a/lib/cog_api/resources/bundle.ex
+++ b/lib/cog_api/resources/bundle.ex
@@ -22,4 +22,12 @@ defmodule CogApi.Resources.Bundle do
       commands: [%CogApi.Resources.Command{}],
     }
   end
+
+  def fake_server_information do
+    %{
+      key: :bundles,
+      associations: [
+      ]
+    }
+  end
 end

--- a/lib/cog_api/resources/group.ex
+++ b/lib/cog_api/resources/group.ex
@@ -14,4 +14,12 @@ defmodule CogApi.Resources.Group do
       users: [%CogApi.Resources.User{}],
     }
   end
+
+  def fake_server_information do
+    %{
+      key: :groups,
+      associations: [
+      ]
+    }
+  end
 end

--- a/lib/cog_api/resources/permission.ex
+++ b/lib/cog_api/resources/permission.ex
@@ -6,4 +6,12 @@ defmodule CogApi.Resources.Permission do
     :name,
     :namespace,
   ]
+
+  def fake_server_information do
+    %{
+      key: :permissions,
+      associations: [
+      ]
+    }
+  end
 end

--- a/lib/cog_api/resources/relay.ex
+++ b/lib/cog_api/resources/relay.ex
@@ -15,4 +15,12 @@ defmodule CogApi.Resources.Relay do
       groups: [%CogApi.Resources.RelayGroup{}],
     }
   end
+
+  def fake_server_information do
+    %{
+      key: :relays,
+      associations: [
+      ]
+    }
+  end
 end

--- a/lib/cog_api/resources/relay_group.ex
+++ b/lib/cog_api/resources/relay_group.ex
@@ -1,5 +1,6 @@
 defmodule CogApi.Resources.RelayGroup do
   @derive [Poison.Encoder]
+  alias CogApi.Resources.Relay
 
   defstruct [
     :id,
@@ -13,7 +14,16 @@ defmodule CogApi.Resources.RelayGroup do
   def format do
     %__MODULE__{
       bundles: [%CogApi.Resources.Bundle{}],
-      relays: [%CogApi.Resources.Relay{}],
+      relays: [%Relay{}],
+    }
+  end
+
+  def fake_server_information do
+    %{
+      key: :relay_groups,
+      associations: [
+        relays: Relay.fake_server_information,
+      ]
     }
   end
 end

--- a/lib/cog_api/resources/role.ex
+++ b/lib/cog_api/resources/role.ex
@@ -12,4 +12,12 @@ defmodule CogApi.Resources.Role do
       permissions: [%CogApi.Resources.Permission{}],
     }
   end
+
+  def fake_server_information do
+    %{
+      key: :roles,
+      associations: [
+      ]
+    }
+  end
 end

--- a/lib/cog_api/resources/rule.ex
+++ b/lib/cog_api/resources/rule.ex
@@ -6,4 +6,12 @@ defmodule CogApi.Resources.Rule do
     :command,
     :rule,
   ]
+
+  def fake_server_information do
+    %{
+      key: :rules,
+      associations: [
+      ]
+    }
+  end
 end

--- a/lib/cog_api/resources/user.ex
+++ b/lib/cog_api/resources/user.ex
@@ -15,4 +15,12 @@ defmodule CogApi.Resources.User do
       groups: [%CogApi.Resources.Group{}],
     }
   end
+
+  def fake_server_information do
+    %{
+      key: :users,
+      associations: [
+      ]
+    }
+  end
 end

--- a/test/unit/cog_api/fake/bundles_test.exs
+++ b/test/unit/cog_api/fake/bundles_test.exs
@@ -17,7 +17,7 @@ defmodule CogApi.Fake.BundlesTest do
 
     it "returns a list of bundles" do
       bundle = %Bundle{id: "id123", name: "a bundle"}
-      Server.create(:bundles, bundle)
+      Server.create(Bundle.fake_server_information, bundle)
 
       {:ok, bundles} = Client.bundle_index(fake_endpoint)
 
@@ -92,7 +92,7 @@ defmodule CogApi.Fake.BundlesTest do
 
     it "only updates the enabled attribute" do
       bundle = %Bundle{id: "id123", name: "a bundle", enabled: true}
-      Server.create(:bundles, bundle)
+      Server.create(Bundle.fake_server_information, bundle)
 
       {:error, error} = Client.bundle_update(
         fake_endpoint,

--- a/test/unit/cog_api/fake/relay_groups_test.exs
+++ b/test/unit/cog_api/fake/relay_groups_test.exs
@@ -90,6 +90,20 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
       assert first_group.id == group.id
     end
+
+    it "handles a relay that was externally updated" do
+      relay = Client.relay_create(%{name: "original_name", token: "1234"}, fake_endpoint) |> get_value
+      group = Client.relay_group_create(%{name: "group"}, fake_endpoint) |> get_value
+      group = Client.relay_group_add_relay(group.id, relay.id, fake_endpoint) |> get_value
+
+      new_name = "updated_name"
+      Client.relay_update(relay.id, %{name: new_name}, fake_endpoint)
+
+      group = Client.relay_group_show(group.id, fake_endpoint) |> get_value
+      [relay_name] = group.relays |> Enum.map(fn relay -> relay.name end)
+
+      assert relay_name == new_name
+    end
   end
 
   describe "relay_group_remove_relay" do

--- a/test/unit/cog_api/fake/server_test.exs
+++ b/test/unit/cog_api/fake/server_test.exs
@@ -1,0 +1,76 @@
+defmodule CogApi.Fake.ServerTest do
+  use CogApi.FakeCase
+
+  alias CogApi.Resources.RelayGroup
+  alias CogApi.Resources.Relay
+
+  alias CogApi.Fake.Server
+
+  describe "index" do
+    it "expands the relationships based on the server_information" do
+      relay = %Relay{id: 1}
+      relay_group = %RelayGroup{id: 1, relays: [relay]}
+      Server.create(Relay.fake_server_information, relay)
+      Server.create(RelayGroup.fake_server_information, relay_group)
+
+      [group_from_server] = Server.index(RelayGroup.fake_server_information)
+
+      assert group_from_server.relays == [relay]
+    end
+  end
+
+  describe "show" do
+    it "expands the relationships based on the server_information" do
+      relay = %Relay{id: 1}
+      relay_group = %RelayGroup{id: 1, relays: [relay]}
+      Server.create(RelayGroup.fake_server_information, relay_group)
+      Server.create(Relay.fake_server_information, relay)
+
+      group_from_server = Server.show(RelayGroup.fake_server_information, relay_group.id)
+
+      assert group_from_server.relays == [relay]
+    end
+  end
+
+  describe "show_by_key" do
+    it "expands the relationships based on the server_information" do
+      relay = %Relay{id: 1}
+      relay_group = %RelayGroup{id: 1, relays: [relay], name: "GROUP"}
+      Server.create(RelayGroup.fake_server_information, relay_group)
+      Server.create(Relay.fake_server_information, relay)
+
+      group_from_server = Server.show_by_key(RelayGroup.fake_server_information, :name, relay_group.name)
+
+      assert group_from_server.relays == [relay]
+    end
+  end
+
+  describe "create" do
+    it "compresses the relationships to only store the ID" do
+      relay = Server.create(Relay.fake_server_information, %Relay{id: 1})
+      relay_group = %RelayGroup{id: 1, relays: [relay]}
+      group = Server.create(RelayGroup.fake_server_information, relay_group)
+
+      assert group.relays == [relay]
+
+      group = Server.raw_show(RelayGroup.fake_server_information, group.id)
+
+      assert group.relays == [relay.id]
+    end
+  end
+
+  describe "update" do
+    it "compresses the relationships to only store the ID" do
+      relay = Server.create(Relay.fake_server_information, %Relay{id: 1})
+      group = %RelayGroup{id: 1, relays: []}
+      group = Server.create(RelayGroup.fake_server_information, group)
+
+      group = Server.update(RelayGroup.fake_server_information, group.id, %{group | relays: [relay]})
+      assert group.relays == [relay]
+
+      group = Server.raw_show(RelayGroup.fake_server_information, group.id)
+
+      assert group.relays == [relay.id]
+    end
+  end
+end


### PR DESCRIPTION
Storing as full objects will work fine about 90% of the time the problem comes in a scenario like this:

* Create a relay group
* Add a relay called "bob" to that relay group

All is well and good!

Then:
* Change the name of that relay to be "bill" instead of "bob"

Now, if you go to "edit" the relay, it will be named properly but when you list all the relays for that relay group, there is actually a copy of the relay but it is still named "bill".

This changes to a pattern where we can store the associations as ids and then expand them when they're pulled out of the server. This is an "opt-in" system and I only opted in on the one place we need them for now.

I also changed to using a `fake_server_information`. I think this makes it a bit easier and you need to know less about the server when making calls and instead, the resource knows how to handle that. It also gives us a place to define those relationships that I'm certain we'll want to utilize more moving forward.