### PR TITLE
Get associations bidirectionally

### DIFF
--- a/lib/cog_api/fake/bundles.ex
+++ b/lib/cog_api/fake/bundles.ex
@@ -9,12 +9,12 @@ defmodule CogApi.Fake.Bundles do
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(Bundle.fake_server_information)}
+    {:ok, Server.index(Bundle)}
   end
 
   def show(%Endpoint{token: nil}, _),  do: Endpoint.invalid_endpoint
   def show(%Endpoint{}=endpoint, id) do
-    bundle = Server.show(Bundle.fake_server_information, id)
+    bundle = Server.show(Bundle, id)
     bundle = %{bundle | commands: add_rules(endpoint, bundle)}
     {:ok, bundle}
   end
@@ -34,22 +34,22 @@ defmodule CogApi.Fake.Bundles do
   def create(%Endpoint{token: _}, params) do
     new_bundle = %Bundle{id: random_string(8)}
     new_bundle = Map.merge(new_bundle, params)
-    {:ok, Server.create(Bundle.fake_server_information, new_bundle)}
+    {:ok, Server.create(Bundle, new_bundle)}
   end
 
   def update(%Endpoint{token: _}, %{name: name}, %{enabled: enabled} = params) do
     catch_errors params, fn ->
-      current_bundle = Server.show_by_key(Bundle.fake_server_information, :name, name)
+      current_bundle = Server.show_by_key(Bundle, :name, name)
       updated_bundle = %{current_bundle | enabled: ensure_bundle_encode_status(enabled)}
-      {:ok, Server.update(Bundle.fake_server_information, current_bundle.id, updated_bundle)}
+      {:ok, Server.update(Bundle, current_bundle.id, updated_bundle)}
     end
   end
   def update(%Endpoint{token: _}, id, %{enabled: enabled} = params) do
     catch_errors params, fn ->
-      current_bundle = Server.show(Bundle.fake_server_information, id)
+      current_bundle = Server.show(Bundle, id)
       updated_bundle = %{current_bundle | enabled: ensure_bundle_encode_status(enabled)}
 
-      {:ok, Server.update(Bundle.fake_server_information, id, updated_bundle)}
+      {:ok, Server.update(Bundle, id, updated_bundle)}
     end
   end
 
@@ -59,8 +59,8 @@ defmodule CogApi.Fake.Bundles do
 
   def delete(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id) do
-    if Server.show(Bundle.fake_server_information, id) do
-      Server.delete(Bundle.fake_server_information, id)
+    if Server.show(Bundle, id) do
+      Server.delete(Bundle, id)
       :ok
     else
       {:error, ["The bundle could not be deleted"]}

--- a/lib/cog_api/fake/groups.ex
+++ b/lib/cog_api/fake/groups.ex
@@ -9,17 +9,17 @@ defmodule CogApi.Fake.Groups do
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(Group.fake_server_information)}
+    {:ok, Server.index(Group)}
   end
 
   def show(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def show(%Endpoint{token: _}, id) do
-    {:ok, Server.show(Group.fake_server_information, id)}
+    {:ok, Server.show(Group, id)}
   end
 
   def find(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def find(%Endpoint{token: _}, params) do
-    groups = Server.index(Group.fake_server_information)
+    groups = Server.index(Group)
     case Enum.find(groups, &(&1.name == params[:name])) do
       nil ->
         {:error, "Group not found"}
@@ -31,20 +31,20 @@ defmodule CogApi.Fake.Groups do
   def create(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def create(%Endpoint{token: _}, %{name: name}) do
     new_group = %Group{id: random_string(8), name: name}
-    {:ok, Server.create(Group.fake_server_information, new_group)}
+    {:ok, Server.create(Group, new_group)}
   end
 
   def update(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def update(%Endpoint{token: _}, id, %{name: _name}=params) do
     catch_errors params, fn ->
-      {:ok, Server.update(Group.fake_server_information, id, params)}
+      {:ok, Server.update(Group, id, params)}
     end
   end
 
   def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id) do
-    if Server.show(Group.fake_server_information, id) do
-      Server.delete(Group.fake_server_information, id)
+    if Server.show(Group, id) do
+      Server.delete(Group, id)
       :ok
     else
       {:error, ["The group could not be deleted"]}
@@ -53,21 +53,21 @@ defmodule CogApi.Fake.Groups do
 
   def add_user(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def add_user(%Endpoint{token: _}, group, user) do
-    user = Server.show_by_key(User.fake_server_information, :email_address, user.email_address)
-    group = Server.show(Group.fake_server_information, group.id)
+    user = Server.show_by_key(User, :email_address, user.email_address)
+    group = Server.show(Group, group.id)
     users = group.users ++ [user]
     group = %{group | users: users}
 
-    {:ok, Server.update(Group.fake_server_information, group.id, group)}
+    {:ok, Server.update(Group, group.id, group)}
   end
 
   def remove_user(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def remove_user(%Endpoint{token: _}, group, user) do
-    user = Server.show_by_key(User.fake_server_information, :email_address, user.email_address)
-    group = Server.show(Group.fake_server_information, group.id)
+    user = Server.show_by_key(User, :email_address, user.email_address)
+    group = Server.show(Group, group.id)
     users = group.users -- [user]
     group = %{group | users: users}
 
-    {:ok, Server.update(Group.fake_server_information, group.id, group)}
+    {:ok, Server.update(Group, group.id, group)}
   end
 end

--- a/lib/cog_api/fake/permissions.ex
+++ b/lib/cog_api/fake/permissions.ex
@@ -8,7 +8,7 @@ defmodule CogApi.Fake.Permissions do
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(Permission.fake_server_information)}
+    {:ok, Server.index(Permission)}
   end
 
   def create(%Endpoint{token: nil}, %{name: _}), do: Endpoint.invalid_endpoint
@@ -21,7 +21,7 @@ defmodule CogApi.Fake.Permissions do
       namespace: %Namespace{id: random_string(8), name: namespace},
     }
 
-    {:ok, Server.create(Permission.fake_server_information, new_permission)}
+    {:ok, Server.create(Permission, new_permission)}
   end
 
   defp build_namespaced_name(name) do

--- a/lib/cog_api/fake/relay_groups.ex
+++ b/lib/cog_api/fake/relay_groups.ex
@@ -8,29 +8,29 @@ defmodule CogApi.Fake.RelayGroups do
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(RelayGroup.fake_server_information)}
+    {:ok, Server.index(RelayGroup)}
   end
 
   def show(_, %Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def show(id, %Endpoint{}) do
-    {:ok, Server.show(RelayGroup.fake_server_information, id)}
+    {:ok, Server.show(RelayGroup, id)}
   end
 
   def create(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def create(%{name: name}, %Endpoint{token: _}) do
     new_relay_group = %RelayGroup{id: random_string(8), name: name, relays: []}
-    {:ok, Server.create(RelayGroup.fake_server_information, new_relay_group)}
+    {:ok, Server.create(RelayGroup, new_relay_group)}
   end
 
   def update(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def update(id, params, %Endpoint{token: _}) do
-    {:ok, Server.update(RelayGroup.fake_server_information, id, params)}
+    {:ok, Server.update(RelayGroup, id, params)}
   end
 
   def delete(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def delete(id, %Endpoint{token: _}) do
-    if Server.show(RelayGroup.fake_server_information, id) do
-      Server.delete(RelayGroup.fake_server_information, id)
+    if Server.show(RelayGroup, id) do
+      Server.delete(RelayGroup, id)
       :ok
     else
       {:error, ["The relay group could not be deleted"]}
@@ -39,27 +39,27 @@ defmodule CogApi.Fake.RelayGroups do
 
   def add_relay(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def add_relay(id, relay_id, %Endpoint{token: _}) do
-    relay = Server.show(Relay.fake_server_information, relay_id)
-    relay_group = Server.show(RelayGroup.fake_server_information, id)
+    relay = Server.show(Relay, relay_id)
+    relay_group = Server.show(RelayGroup, id)
     relay_with_group = %{relay | groups: relay.groups ++ [relay_group]}
-    Server.update(Relay.fake_server_information, relay.id, relay_with_group)
+    Server.update(Relay, relay.id, relay_with_group)
 
     relays = relay_group.relays ++ [relay_with_group]
     relay_group = %{relay_group | relays: relays}
 
-    {:ok, Server.update(RelayGroup.fake_server_information, id, relay_group)}
+    {:ok, Server.update(RelayGroup, id, relay_group)}
   end
 
   def remove_relay(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def remove_relay(id, relay_id, %Endpoint{token: _}) do
-    relay = Server.show(Relay.fake_server_information, relay_id)
-    relay_group = Server.show(RelayGroup.fake_server_information, id)
+    relay = Server.show(Relay, relay_id)
+    relay_group = Server.show(RelayGroup, id)
     relays = relay_group.relays -- [relay]
     relay_group = %{relay_group | relays: relays}
 
     relay_without_group = %{relay | groups: relay.groups -- [relay_group]}
-    Server.update(Relay.fake_server_information, relay.id, relay_without_group)
+    Server.update(Relay, relay.id, relay_without_group)
 
-    {:ok, Server.update(RelayGroup.fake_server_information, id, relay_group)}
+    {:ok, Server.update(RelayGroup, id, relay_group)}
   end
 end

--- a/lib/cog_api/fake/relays.ex
+++ b/lib/cog_api/fake/relays.ex
@@ -8,12 +8,12 @@ defmodule CogApi.Fake.Relays do
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(Relay.fake_server_information)}
+    {:ok, Server.index(Relay)}
   end
 
   def show(_, %Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def show(id, %Endpoint{}) do
-    {:ok, Server.show(Relay.fake_server_information, id)}
+    {:ok, Server.show(Relay, id)}
   end
 
   def create(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
@@ -21,21 +21,21 @@ defmodule CogApi.Fake.Relays do
     catch_errors params, fn ->
       new_relay = %Relay{id: random_string(8)}
       new_relay = Map.merge(new_relay, params)
-      {:ok, Server.create(Relay.fake_server_information, new_relay)}
+      {:ok, Server.create(Relay, new_relay)}
     end
   end
 
   def update(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def update(id, params, %Endpoint{token: _}) do
     catch_errors params, fn ->
-      {:ok, Server.update(Relay.fake_server_information, id, params)}
+      {:ok, Server.update(Relay, id, params)}
     end
   end
 
   def delete(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def delete(id, %Endpoint{token: _}) do
-    if Server.show(Relay.fake_server_information, id) do
-      Server.delete(Relay.fake_server_information, id)
+    if Server.show(Relay, id) do
+      Server.delete(Relay, id)
       :ok
     else
       {:error, ["The relay could not be deleted"]}

--- a/lib/cog_api/fake/roles.ex
+++ b/lib/cog_api/fake/roles.ex
@@ -9,51 +9,51 @@ defmodule CogApi.Fake.Roles do
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(Role.fake_server_information)}
+    {:ok, Server.index(Role)}
   end
 
   def show(%Endpoint{token: nil}, _),  do: Endpoint.invalid_endpoint
   def show(%Endpoint{}, %{name: name}) do
-    {:ok, Server.show_by_key(Role.fake_server_information, :name, name)}
+    {:ok, Server.show_by_key(Role, :name, name)}
   end
   def show(%Endpoint{}, id) do
-    {:ok, Server.show(Role.fake_server_information, id)}
+    {:ok, Server.show(Role, id)}
   end
 
   def create(%Endpoint{token: nil}, %{name: _}), do: Endpoint.invalid_endpoint
   def create(%Endpoint{token: _}, %{name: name}) do
     new_role = %Role{id: random_string(8), name: name}
-    {:ok, Server.create(Role.fake_server_information, new_role)}
+    {:ok, Server.create(Role, new_role)}
   end
 
   def update(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def update(%Endpoint{token: _}, id, params) do
-    {:ok, Server.update(Role.fake_server_information, id, params)}
+    {:ok, Server.update(Role, id, params)}
   end
 
   def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id) do
-    Server.delete(Role.fake_server_information, id)
+    Server.delete(Role, id)
     :ok
   end
 
   def grant(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def grant(%Endpoint{}, role, group) do
     group = %{group | roles: group.roles ++ [role]}
-    {:ok, Server.update(Group.fake_server_information, group.id, group)}
+    {:ok, Server.update(Group, group.id, group)}
   end
 
   def revoke(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def revoke(%Endpoint{}, role, group) do
     group = %{group | roles: List.delete(group.roles, role)}
-    {:ok, Server.update(Group.fake_server_information, group.id, group)}
+    {:ok, Server.update(Group, group.id, group)}
   end
 
   def add_permission(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def add_permission(%Endpoint{}, role, permission) do
-    if found_permission  = Server.show(Permission.fake_server_information, permission.id) do
+    if found_permission  = Server.show(Permission, permission.id) do
       role = %{role | permissions: role.permissions ++ [found_permission]}
-      {:ok, Server.update(Role.fake_server_information, role.id, role)}
+      {:ok, Server.update(Role, role.id, role)}
     else
       {:error, ["Not found permissions - #{Permission.full_name(permission)}"]}
     end
@@ -62,6 +62,6 @@ defmodule CogApi.Fake.Roles do
   def remove_permission(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def remove_permission(%Endpoint{}, role, permission) do
     role = %{role | permissions: List.delete(role.permissions, permission)}
-    {:ok, Server.update(Role.fake_server_information, role.id, role)}
+    {:ok, Server.update(Role, role.id, role)}
   end
 end

--- a/lib/cog_api/fake/rules.ex
+++ b/lib/cog_api/fake/rules.ex
@@ -8,7 +8,7 @@ defmodule CogApi.Fake.Rules do
   def index(_, %Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(command, %Endpoint{}) do
     rules =
-    Server.index(Rule.fake_server_information)
+    Server.index(Rule)
     |> Enum.filter(fn rule -> rule.command == command end)
     {:ok, rules}
   end
@@ -23,14 +23,14 @@ defmodule CogApi.Fake.Rules do
         id: random_string(8),
         rule: rule,
       }
-      {:ok, Server.create(Rule.fake_server_information, new_rule)}
+      {:ok, Server.create(Rule, new_rule)}
     end
   end
 
   def delete(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def delete(id, %Endpoint{token: _}) do
-    if Server.show(Rule.fake_server_information, id) do
-      Server.delete(Rule.fake_server_information, id)
+    if Server.show(Rule, id) do
+      Server.delete(Rule, id)
     else
       {:error, ["The rule could not be deleted"]}
     end

--- a/lib/cog_api/fake/users.ex
+++ b/lib/cog_api/fake/users.ex
@@ -8,12 +8,12 @@ defmodule CogApi.Fake.Users do
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
-    {:ok, Server.index(User.fake_server_information)}
+    {:ok, Server.index(User)}
   end
 
   def show(%Endpoint{token: nil}, _),  do: Endpoint.invalid_endpoint
   def show(%Endpoint{}, id) do
-    {:ok, Server.show(User.fake_server_information, id)}
+    {:ok, Server.show(User, id)}
   end
 
   def create(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
@@ -21,20 +21,20 @@ defmodule CogApi.Fake.Users do
     catch_errors params, fn ->
       new_user = %User{id: random_string(8)}
       new_user = Map.merge(new_user, params)
-      {:ok, Server.create(User.fake_server_information, new_user)}
+      {:ok, Server.create(User, new_user)}
     end
   end
 
   def update(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def update(%Endpoint{token: _}, id, params) do
     catch_errors params, fn ->
-      {:ok, Server.update(User.fake_server_information, id, params)}
+      {:ok, Server.update(User, id, params)}
     end
   end
 
   def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id) do
-    Server.delete(User.fake_server_information, id)
+    Server.delete(User, id)
     :ok
   end
 end

--- a/lib/cog_api/http/groups.ex
+++ b/lib/cog_api/http/groups.ex
@@ -56,12 +56,12 @@ defmodule CogApi.HTTP.Groups do
 
   defp format_group_response(response) do
     json_structure = %{"group" => GroupDecoder.format}
-    groups = Poison.decode!(response.body, as: json_structure)["group"]
+    group = Poison.decode!(response.body, as: json_structure)["group"]
     |> GroupDecoder.to_group
 
     {
       ApiResponse.type(response),
-      groups
+      group
     }
   end
 

--- a/lib/cog_api/resources/bundle.ex
+++ b/lib/cog_api/resources/bundle.ex
@@ -23,11 +23,11 @@ defmodule CogApi.Resources.Bundle do
     }
   end
 
-  def fake_server_information do
-    %{
-      key: :bundles,
-      associations: [
-      ]
-    }
+  def fake_key do
+    :bundles
+  end
+
+  def associations do
+    []
   end
 end

--- a/lib/cog_api/resources/group.ex
+++ b/lib/cog_api/resources/group.ex
@@ -15,11 +15,12 @@ defmodule CogApi.Resources.Group do
     }
   end
 
-  def fake_server_information do
-    %{
-      key: :groups,
-      associations: [
-      ]
-    }
+  def fake_key do
+    :groups
+  end
+
+  def associations do
+    [
+    ]
   end
 end

--- a/lib/cog_api/resources/group.ex
+++ b/lib/cog_api/resources/group.ex
@@ -21,6 +21,7 @@ defmodule CogApi.Resources.Group do
 
   def associations do
     [
+      users: CogApi.Resources.User,
     ]
   end
 end

--- a/lib/cog_api/resources/permission.ex
+++ b/lib/cog_api/resources/permission.ex
@@ -12,12 +12,12 @@ defmodule CogApi.Resources.Permission do
     }
   end
 
-  def fake_server_information do
-    %{
-      key: :permissions,
-      associations: [
-      ]
-    }
+  def fake_key do
+    :permissions
+  end
+
+  def associations do
+    []
   end
 
   def full_name(%{name: name, namespace: namespace}) do

--- a/lib/cog_api/resources/relay.ex
+++ b/lib/cog_api/resources/relay.ex
@@ -16,11 +16,11 @@ defmodule CogApi.Resources.Relay do
     }
   end
 
-  def fake_server_information do
-    %{
-      key: :relays,
-      associations: [
-      ]
-    }
+  def fake_key do
+    :relays
+  end
+
+  def associations do
+    []
   end
 end

--- a/lib/cog_api/resources/relay_group.ex
+++ b/lib/cog_api/resources/relay_group.ex
@@ -18,12 +18,13 @@ defmodule CogApi.Resources.RelayGroup do
     }
   end
 
-  def fake_server_information do
-    %{
-      key: :relay_groups,
-      associations: [
-        relays: Relay.fake_server_information,
-      ]
-    }
+  def fake_key do
+    :relay_groups
+  end
+
+  def associations do
+    [
+      relays: Relay,
+    ]
   end
 end

--- a/lib/cog_api/resources/role.ex
+++ b/lib/cog_api/resources/role.ex
@@ -15,12 +15,13 @@ defmodule CogApi.Resources.Role do
     }
   end
 
-  def fake_server_information do
-    %{
-      key: :roles,
-      associations: [
-        permissions: Permission.fake_server_information,
-      ]
-    }
+  def fake_key do
+    :roles
+  end
+
+  def associations do
+    [
+      permissions: Permission,
+    ]
   end
 end

--- a/lib/cog_api/resources/rule.ex
+++ b/lib/cog_api/resources/rule.ex
@@ -7,11 +7,11 @@ defmodule CogApi.Resources.Rule do
     :rule,
   ]
 
-  def fake_server_information do
-    %{
-      key: :rules,
-      associations: [
-      ]
-    }
+  def fake_key do
+    :rules
+  end
+
+  def associations do
+    []
   end
 end

--- a/lib/cog_api/resources/user.ex
+++ b/lib/cog_api/resources/user.ex
@@ -1,6 +1,8 @@
 defmodule CogApi.Resources.User do
   @derive [Poison.Encoder]
 
+  alias CogApi.Resources.Group
+
   defstruct [
     :id,
     :first_name,
@@ -12,15 +14,17 @@ defmodule CogApi.Resources.User do
 
   def format do
     %__MODULE__{
-      groups: [%CogApi.Resources.Group{}],
+      groups: [%Group{}],
     }
   end
 
-  def fake_server_information do
-    %{
-      key: :users,
-      associations: [
-      ]
-    }
+  def fake_key do
+    :users
+  end
+
+  def associations do
+    [
+      groups: Group
+    ]
   end
 end

--- a/test/unit/cog_api/fake/bundles_test.exs
+++ b/test/unit/cog_api/fake/bundles_test.exs
@@ -17,7 +17,7 @@ defmodule CogApi.Fake.BundlesTest do
 
     it "returns a list of bundles" do
       bundle = %Bundle{id: "id123", name: "a bundle"}
-      Server.create(Bundle.fake_server_information, bundle)
+      Server.create(Bundle, bundle)
 
       {:ok, bundles} = Client.bundle_index(fake_endpoint)
 
@@ -92,7 +92,7 @@ defmodule CogApi.Fake.BundlesTest do
 
     it "only updates the enabled attribute" do
       bundle = %Bundle{id: "id123", name: "a bundle", enabled: true}
-      Server.create(Bundle.fake_server_information, bundle)
+      Server.create(Bundle, bundle)
 
       {:error, error} = Client.bundle_update(
         fake_endpoint,

--- a/test/unit/cog_api/fake/server_test.exs
+++ b/test/unit/cog_api/fake/server_test.exs
@@ -10,10 +10,10 @@ defmodule CogApi.Fake.ServerTest do
     it "expands the relationships based on the server_information" do
       relay = %Relay{id: 1}
       relay_group = %RelayGroup{id: 1, relays: [relay]}
-      Server.create(Relay.fake_server_information, relay)
-      Server.create(RelayGroup.fake_server_information, relay_group)
+      Server.create(Relay, relay)
+      Server.create(RelayGroup, relay_group)
 
-      [group_from_server] = Server.index(RelayGroup.fake_server_information)
+      [group_from_server] = Server.index(RelayGroup)
 
       assert group_from_server.relays == [relay]
     end
@@ -23,10 +23,10 @@ defmodule CogApi.Fake.ServerTest do
     it "expands the relationships based on the server_information" do
       relay = %Relay{id: 1}
       relay_group = %RelayGroup{id: 1, relays: [relay]}
-      Server.create(RelayGroup.fake_server_information, relay_group)
-      Server.create(Relay.fake_server_information, relay)
+      Server.create(RelayGroup, relay_group)
+      Server.create(Relay, relay)
 
-      group_from_server = Server.show(RelayGroup.fake_server_information, relay_group.id)
+      group_from_server = Server.show(RelayGroup, relay_group.id)
 
       assert group_from_server.relays == [relay]
     end
@@ -36,10 +36,10 @@ defmodule CogApi.Fake.ServerTest do
     it "expands the relationships based on the server_information" do
       relay = %Relay{id: 1}
       relay_group = %RelayGroup{id: 1, relays: [relay], name: "GROUP"}
-      Server.create(RelayGroup.fake_server_information, relay_group)
-      Server.create(Relay.fake_server_information, relay)
+      Server.create(RelayGroup, relay_group)
+      Server.create(Relay, relay)
 
-      group_from_server = Server.show_by_key(RelayGroup.fake_server_information, :name, relay_group.name)
+      group_from_server = Server.show_by_key(RelayGroup, :name, relay_group.name)
 
       assert group_from_server.relays == [relay]
     end
@@ -47,13 +47,13 @@ defmodule CogApi.Fake.ServerTest do
 
   describe "create" do
     it "compresses the relationships to only store the ID" do
-      relay = Server.create(Relay.fake_server_information, %Relay{id: 1})
+      relay = Server.create(Relay, %Relay{id: 1})
       relay_group = %RelayGroup{id: 1, relays: [relay]}
-      group = Server.create(RelayGroup.fake_server_information, relay_group)
+      group = Server.create(RelayGroup, relay_group)
 
       assert group.relays == [relay]
 
-      group = Server.raw_show(RelayGroup.fake_server_information, group.id)
+      group = Server.raw_show(RelayGroup, group.id)
 
       assert group.relays == [relay.id]
     end
@@ -61,14 +61,14 @@ defmodule CogApi.Fake.ServerTest do
 
   describe "update" do
     it "compresses the relationships to only store the ID" do
-      relay = Server.create(Relay.fake_server_information, %Relay{id: 1})
+      relay = Server.create(Relay, %Relay{id: 1})
       group = %RelayGroup{id: 1, relays: []}
-      group = Server.create(RelayGroup.fake_server_information, group)
+      group = Server.create(RelayGroup, group)
 
-      group = Server.update(RelayGroup.fake_server_information, group.id, %{group | relays: [relay]})
+      group = Server.update(RelayGroup, group.id, %{group | relays: [relay]})
       assert group.relays == [relay]
 
-      group = Server.raw_show(RelayGroup.fake_server_information, group.id)
+      group = Server.raw_show(RelayGroup, group.id)
 
       assert group.relays == [relay.id]
     end


### PR DESCRIPTION
The way this worked previously, `fake_server_information` was being
called recursively. This made bidirectional associations impossible,
because by referencing each other in their `fake_server_information`
functions, it would enter an infinite loop.