### PR TITLE
Do not use a Namespace resource

### DIFF
--- a/lib/cog_api/fake/permissions.ex
+++ b/lib/cog_api/fake/permissions.ex
@@ -4,7 +4,6 @@ defmodule CogApi.Fake.Permissions do
   alias CogApi.Endpoint
   alias CogApi.Fake.Server
   alias CogApi.Resources.Permission
-  alias CogApi.Resources.Namespace
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
@@ -18,7 +17,7 @@ defmodule CogApi.Fake.Permissions do
     new_permission = %Permission{
       id: random_string(8),
       name: name,
-      namespace: %Namespace{id: random_string(8), name: namespace},
+      namespace: namespace,
     }
 
     {:ok, Server.create(Permission, new_permission)}

--- a/lib/cog_api/resources/namespace.ex
+++ b/lib/cog_api/resources/namespace.ex
@@ -1,8 +1,0 @@
-defmodule CogApi.Resources.Namespace do
-  @derive [Poison.Encoder]
-
-  defstruct [
-    :id,
-    :name,
-  ]
-end

--- a/test/unit/cog_api/fake/permissions_test.exs
+++ b/test/unit/cog_api/fake/permissions_test.exs
@@ -14,7 +14,7 @@ defmodule CogApi.Fake.PermissionsTest do
       first_permission = List.first permissions
       assert present first_permission.id
       assert first_permission.name == "foobar"
-      assert first_permission.namespace.name == "custom"
+      assert first_permission.namespace == "custom"
     end
   end
 
@@ -25,8 +25,7 @@ defmodule CogApi.Fake.PermissionsTest do
 
       assert present permission.id
       assert permission.name == "view_all_things"
-      assert present permission.namespace.id
-      assert permission.namespace.name == "site"
+      assert permission.namespace == "site"
     end
 
     it "allows creating permissions in specifc namespaces" do
@@ -35,8 +34,7 @@ defmodule CogApi.Fake.PermissionsTest do
 
       assert present permission.id
       assert permission.name == "foobar"
-      assert present permission.namespace.id
-      assert permission.namespace.name == "custom"
+      assert permission.namespace == "custom"
     end
   end
 end


### PR DESCRIPTION
Previously, the API would respond with a Namespace resource. This now just a single string. This updates the Fake CogApi to respect that change.