### PR TITLE
Error handling for adding a relay to a relay group

### DIFF
--- a/lib/cog_api/client.ex
+++ b/lib/cog_api/client.ex
@@ -53,8 +53,8 @@ defmodule CogApi.Client do
   @callback relay_group_update(String.t, %{}, %Endpoint{}) :: {atom, %RelayGroup{}}
   @callback relay_group_delete(String.t, %Endpoint{}) :: atom
   @callback relay_group_delete(String.t, %Endpoint{}) :: {atom, [String.t]}
-  @callback relay_group_add_relays(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
-  @callback relay_group_add_relays(Map.t, Map.t, %Endpoint{}) :: {atom, %RelayGroup{}}
+  @callback relay_group_add_relays_by_name(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
+  @callback relay_group_add_relays_by_id(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
   @callback relay_group_remove_relays(String.t, String.t, %Endpoint{}) :: {atom, %RelayGroup{}}
   @callback relay_group_remove_relays(Map.t, Map.t, %Endpoint{}) :: {atom, %RelayGroup{}}
   @callback relay_group_add_bundles(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}

--- a/lib/cog_api/client.ex
+++ b/lib/cog_api/client.ex
@@ -55,12 +55,12 @@ defmodule CogApi.Client do
   @callback relay_group_delete(String.t, %Endpoint{}) :: {atom, [String.t]}
   @callback relay_group_add_relays_by_name(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
   @callback relay_group_add_relays_by_id(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
-  @callback relay_group_remove_relays(String.t, String.t, %Endpoint{}) :: {atom, %RelayGroup{}}
-  @callback relay_group_remove_relays(Map.t, Map.t, %Endpoint{}) :: {atom, %RelayGroup{}}
-  @callback relay_group_add_bundles(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
-  @callback relay_group_add_bundles(Map.t, Map.t, %Endpoint{}) :: {atom, %RelayGroup{}}
-  @callback relay_group_remove_bundles(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
-  @callback relay_group_remove_bundles(Map.t, Map.t, %Endpoint{}) :: {atom, %RelayGroup{}}
+  @callback relay_group_remove_relays_by_name(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
+  @callback relay_group_remove_relays_by_id(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
+  @callback relay_group_add_bundles_by_name(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
+  @callback relay_group_add_bundles_by_id(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
+  @callback relay_group_remove_bundles_by_name(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
+  @callback relay_group_remove_bundles_by_id(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
 
   @callback role_index(%Endpoint{}) :: {atom, [%Role{}]}
   @callback role_show(%Endpoint{}, String.t) :: {atom, %Role{}}

--- a/lib/cog_api/client.ex
+++ b/lib/cog_api/client.ex
@@ -53,8 +53,10 @@ defmodule CogApi.Client do
   @callback relay_group_update(String.t, %{}, %Endpoint{}) :: {atom, %RelayGroup{}}
   @callback relay_group_delete(String.t, %Endpoint{}) :: atom
   @callback relay_group_delete(String.t, %Endpoint{}) :: {atom, [String.t]}
-  @callback relay_group_add_relay(String.t, String.t, %Endpoint{}) :: {atom, %RelayGroup{}}
-  @callback relay_group_remove_relay(String.t, String.t, %Endpoint{}) :: {atom, %RelayGroup{}}
+  @callback relay_group_add_relays(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
+  @callback relay_group_add_relays(Map.t, Map.t, %Endpoint{}) :: {atom, %RelayGroup{}}
+  @callback relay_group_remove_relays(String.t, String.t, %Endpoint{}) :: {atom, %RelayGroup{}}
+  @callback relay_group_remove_relays(Map.t, Map.t, %Endpoint{}) :: {atom, %RelayGroup{}}
   @callback relay_group_add_bundles(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}
   @callback relay_group_add_bundles(Map.t, Map.t, %Endpoint{}) :: {atom, %RelayGroup{}}
   @callback relay_group_remove_bundles(String.t, String.t | List.t, %Endpoint{}) :: {atom, %RelayGroup{}}

--- a/lib/cog_api/fake/client.ex
+++ b/lib/cog_api/fake/client.ex
@@ -142,20 +142,36 @@ defmodule CogApi.Fake.Client do
     RelayGroups.delete(relay_group_id, endpoint)
   end
 
-  def relay_group_add_relays(relay_group_id, relay_id, %Endpoint{}=endpoint) do
-    RelayGroups.add_relays(relay_group_id, relay_id, endpoint)
+  def relay_group_add_relays_by_name(relay_group_name, relay_names, %Endpoint{}=endpoint) do
+    RelayGroups.add_relays_by_name(relay_group_name, relay_names, endpoint)
   end
 
-  def relay_group_remove_relays(relay_group_id, relay_id, %Endpoint{}=endpoint) do
-    RelayGroups.remove_relays(relay_group_id, relay_id, endpoint)
+  def relay_group_add_relays_by_id(relay_group_id, relay_ids, %Endpoint{}=endpoint) do
+    RelayGroups.add_relays_by_id(relay_group_id, relay_ids, endpoint)
   end
 
-  def relay_group_add_bundles(relay_group_id, bundle_id, %Endpoint{}=endpoint) do
-    RelayGroups.add_bundles(relay_group_id, bundle_id, endpoint)
+  def relay_group_remove_relays_by_name(relay_group_name, relay_names, %Endpoint{}=endpoint) do
+    RelayGroups.remove_relays_by_name(relay_group_name, relay_names, endpoint)
   end
 
-  def relay_group_remove_bundles(relay_group_id, bundle_id, %Endpoint{}=endpoint) do
-    RelayGroups.remove_bundles(relay_group_id, bundle_id, endpoint)
+  def relay_group_remove_relays_by_id(relay_group_id, relay_ids, %Endpoint{}=endpoint) do
+    RelayGroups.remove_relays_by_id(relay_group_id, relay_ids, endpoint)
+  end
+
+  def relay_group_add_bundles_by_name(relay_group_name, bundle_names, %Endpoint{}=endpoint) do
+    RelayGroups.add_bundles_by_name(relay_group_name, bundle_names, endpoint)
+  end
+
+  def relay_group_add_bundles_by_id(relay_group_id, bundle_ids, %Endpoint{}=endpoint) do
+    RelayGroups.add_bundles_by_id(relay_group_id, bundle_ids, endpoint)
+  end
+
+  def relay_group_remove_bundles_by_name(relay_group_name, bundle_names, %Endpoint{}=endpoint) do
+    RelayGroups.remove_bundles_by_name(relay_group_name, bundle_names, endpoint)
+  end
+
+  def relay_group_remove_bundles_by_id(relay_group_id, bundle_ids, %Endpoint{}=endpoint) do
+    RelayGroups.remove_bundles_by_id(relay_group_id, bundle_ids, endpoint)
   end
 
   def role_index(endpoint) do

--- a/lib/cog_api/fake/client.ex
+++ b/lib/cog_api/fake/client.ex
@@ -142,12 +142,12 @@ defmodule CogApi.Fake.Client do
     RelayGroups.delete(relay_group_id, endpoint)
   end
 
-  def relay_group_add_relay(relay_group_id, relay_id, %Endpoint{}=endpoint) do
-    RelayGroups.add_relay(relay_group_id, relay_id, endpoint)
+  def relay_group_add_relays(relay_group_id, relay_id, %Endpoint{}=endpoint) do
+    RelayGroups.add_relays(relay_group_id, relay_id, endpoint)
   end
 
-  def relay_group_remove_relay(relay_group_id, relay_id, %Endpoint{}=endpoint) do
-    RelayGroups.remove_relay(relay_group_id, relay_id, endpoint)
+  def relay_group_remove_relays(relay_group_id, relay_id, %Endpoint{}=endpoint) do
+    RelayGroups.remove_relays(relay_group_id, relay_id, endpoint)
   end
 
   def relay_group_add_bundles(relay_group_id, bundle_id, %Endpoint{}=endpoint) do

--- a/lib/cog_api/fake/relay_groups.ex
+++ b/lib/cog_api/fake/relay_groups.ex
@@ -52,18 +52,19 @@ defmodule CogApi.Fake.RelayGroups do
   end
   defp delete_relay_group(_), do: return_error("The relay group could not be deleted")
 
-  def add_relays(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
-  def add_relays(%{name: name}, %{relays: relay_names}, %Endpoint{token: _}=endpoint) do
+  def add_relays_by_name(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
+  def add_relays_by_name(name, relay_names, %Endpoint{}=endpoint) do
+    relay_names = List.wrap(relay_names)
     relay_group = Server.show_by_key(RelayGroup, :name, name)
     relay_ids = Enum.map(relay_names, &Server.show_by_key(Relay, :name, &1))
     |> Enum.map(&Map.fetch!(&1, :id))
-    add_relays(relay_group.id, relay_ids, endpoint)
+    add_relays_by_id(relay_group.id, relay_ids, endpoint)
   end
-  def add_relays(id, relay_ids, %Endpoint{token: _}=endpoint) when is_list(relay_ids) do
-    Enum.map(relay_ids, &add_relay(id, &1, endpoint))
-  end
-  def add_relays(id, relay_id, %Endpoint{token: _}=endpoint) do
-    [add_relay(id, relay_id, endpoint)]
+
+  def add_relays_by_id(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
+  def add_relays_by_id(id, relay_ids, %Endpoint{}=endpoint) do
+    List.wrap(relay_ids)
+    |> Enum.map(&add_relay(id, &1, endpoint))
   end
 
   defp add_relay(id, relay_id, %Endpoint{token: _}) do
@@ -79,18 +80,19 @@ defmodule CogApi.Fake.RelayGroups do
     update_relays(relay_with_group, relay_group)
   end
 
-  def remove_relays(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
-  def remove_relays(%{name: name}, %{relays: relay_names}, %Endpoint{token: _}=endpoint) do
+  def remove_relays_by_name(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
+  def remove_relays_by_name(name, relay_names, %Endpoint{}=endpoint) do
+    relay_names = List.wrap(relay_names)
     relay_group = Server.show_by_key(RelayGroup, :name, name)
     relay_ids = Enum.map(relay_names, &Server.show_by_key(Relay, :name, &1))
     |> Enum.map(&Map.fetch!(&1, :id))
-    remove_relays(relay_group.id, relay_ids, endpoint)
+    remove_relays_by_id(relay_group.id, relay_ids, endpoint)
   end
-  def remove_relays(id, relay_ids, %Endpoint{token: _}=endpoint) when is_list(relay_ids) do
-    Enum.map(relay_ids, &remove_relay(id, &1, endpoint))
-  end
-  def remove_relays(id, relay_id, %Endpoint{token: _}=endpoint) do
-    [remove_relay(id, relay_id, endpoint)]
+
+  def remove_relays_by_id(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
+  def remove_relays_by_id(id, relay_ids, %Endpoint{token: _}=endpoint) do
+    List.wrap(relay_ids)
+    |> Enum.map(&remove_relay(id, &1, endpoint))
   end
 
   defp remove_relay(id, relay_id, %Endpoint{token: _}) do
@@ -114,21 +116,22 @@ defmodule CogApi.Fake.RelayGroups do
     {:ok, Server.update(RelayGroup, relay_group.id, relay_group)}
   end
 
-  def add_bundles(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
-  def add_bundles(%{name: name}, %{bundles: bundle_names}, %Endpoint{token: _}=endpoint) do
+  def add_bundles_by_name(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
+  def add_bundles_by_name(name, bundle_names, %Endpoint{}=endpoint) do
+    bundle_names = List.wrap(bundle_names)
     relay_group = Server.show_by_key(RelayGroup, :name, name)
     bundle_ids = Enum.map(bundle_names, &Server.show_by_key(Bundle, :name, &1))
     |> Enum.map(&Map.fetch!(&1, :id))
-    add_bundles(relay_group.id, bundle_ids, endpoint)
-  end
-  def add_bundles(id, bundle_ids, %Endpoint{token: _}=endpoint) when is_list(bundle_ids) do
-    Enum.map(bundle_ids, &add_bundle(id, &1, endpoint))
-  end
-  def add_bundles(id, bundle_id, %Endpoint{token: _}=endpoint) do
-    [add_bundle(id, bundle_id, endpoint)]
+    add_bundles_by_id(relay_group.id, bundle_ids, endpoint)
   end
 
-  defp add_bundle(id, bundle_id, %Endpoint{token: _}) do
+  def add_bundles_by_id(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
+  def add_bundles_by_id(id, bundle_ids, %Endpoint{}=endpoint) do
+    List.wrap(bundle_ids)
+    |> Enum.map(&add_bundle(id, &1, endpoint))
+  end
+
+  defp add_bundle(id, bundle_id, %Endpoint{}) do
     bundle = Server.show(Bundle, bundle_id)
     relay_group = Server.show(RelayGroup, id)
     add_bundle(bundle, relay_group)
@@ -141,18 +144,19 @@ defmodule CogApi.Fake.RelayGroups do
     update_bundles(bundle_with_group, relay_group)
   end
 
-  def remove_bundles(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
-  def remove_bundles(%{name: name}, %{bundles: bundle_names}, %Endpoint{token: _}=endpoint) do
+  def remove_bundles_by_name(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
+  def remove_bundles_by_name(name, bundle_names, %Endpoint{}=endpoint) do
+    bundle_names = List.wrap(bundle_names)
     relay_group = Server.show_by_key(RelayGroup, :name, name)
     bundle_ids = Enum.map(bundle_names, &Server.show_by_key(Bundle, :name, &1))
     |> Enum.map(&Map.fetch!(&1, :id))
-    remove_bundles(relay_group.id, bundle_ids, endpoint)
+    remove_bundles_by_id(relay_group.id, bundle_ids, endpoint)
   end
-  def remove_bundles(id, bundle_ids, %Endpoint{token: _}=endpoint) when is_list(bundle_ids) do
-    Enum.map(bundle_ids, &remove_bundle(id, &1, endpoint))
-  end
-  def remove_bundles(id, bundle_id, %Endpoint{token: _}=endpoint) do
-    [remove_bundle(id, bundle_id, endpoint)]
+
+  def remove_bundles_by_id(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
+  def remove_bundles_by_id(id, bundle_ids, %Endpoint{}=endpoint) do
+    List.wrap(bundle_ids)
+    |> Enum.map(&remove_bundle(id, &1, endpoint))
   end
 
   defp remove_bundle(id, bundle_id, %Endpoint{token: _}) do

--- a/lib/cog_api/fake/relay_groups.ex
+++ b/lib/cog_api/fake/relay_groups.ex
@@ -60,10 +60,13 @@ defmodule CogApi.Fake.RelayGroups do
     add_relays(relay_group.id, relay_ids, endpoint)
   end
   def add_relays(id, relay_ids, %Endpoint{token: _}=endpoint) when is_list(relay_ids) do
-    Enum.map(relay_ids, &add_relays(id, &1, endpoint))
-    |> List.last
+    Enum.map(relay_ids, &add_relay(id, &1, endpoint))
   end
-  def add_relays(id, relay_id, %Endpoint{token: _}) do
+  def add_relays(id, relay_id, %Endpoint{token: _}=endpoint) do
+    [add_relay(id, relay_id, endpoint)]
+  end
+
+  defp add_relay(id, relay_id, %Endpoint{token: _}) do
     relay = Server.show(Relay, relay_id)
     relay_group = Server.show(RelayGroup, id)
     add_relay(relay, relay_group)
@@ -84,10 +87,13 @@ defmodule CogApi.Fake.RelayGroups do
     remove_relays(relay_group.id, relay_ids, endpoint)
   end
   def remove_relays(id, relay_ids, %Endpoint{token: _}=endpoint) when is_list(relay_ids) do
-    Enum.map(relay_ids, &remove_relays(id, &1, endpoint))
-    |> List.last
+    Enum.map(relay_ids, &remove_relay(id, &1, endpoint))
   end
-  def remove_relays(id, relay_id, %Endpoint{token: _}) do
+  def remove_relays(id, relay_id, %Endpoint{token: _}=endpoint) do
+    [remove_relay(id, relay_id, endpoint)]
+  end
+
+  defp remove_relay(id, relay_id, %Endpoint{token: _}) do
     relay = Server.show(Relay, relay_id)
     relay_group = Server.show(RelayGroup, id)
     remove_relay(relay, relay_group)
@@ -116,10 +122,13 @@ defmodule CogApi.Fake.RelayGroups do
     add_bundles(relay_group.id, bundle_ids, endpoint)
   end
   def add_bundles(id, bundle_ids, %Endpoint{token: _}=endpoint) when is_list(bundle_ids) do
-    Enum.map(bundle_ids, &add_bundles(id, &1, endpoint))
-    |> List.last
+    Enum.map(bundle_ids, &add_bundle(id, &1, endpoint))
   end
-  def add_bundles(id, bundle_id, %Endpoint{token: _}) do
+  def add_bundles(id, bundle_id, %Endpoint{token: _}=endpoint) do
+    [add_bundle(id, bundle_id, endpoint)]
+  end
+
+  defp add_bundle(id, bundle_id, %Endpoint{token: _}) do
     bundle = Server.show(Bundle, bundle_id)
     relay_group = Server.show(RelayGroup, id)
     add_bundle(bundle, relay_group)
@@ -140,10 +149,13 @@ defmodule CogApi.Fake.RelayGroups do
     remove_bundles(relay_group.id, bundle_ids, endpoint)
   end
   def remove_bundles(id, bundle_ids, %Endpoint{token: _}=endpoint) when is_list(bundle_ids) do
-    Enum.map(bundle_ids, &remove_bundles(id, &1, endpoint))
-    |> List.last
+    Enum.map(bundle_ids, &remove_bundle(id, &1, endpoint))
   end
-  def remove_bundles(id, bundle_id, %Endpoint{token: _}) do
+  def remove_bundles(id, bundle_id, %Endpoint{token: _}=endpoint) do
+    [remove_bundle(id, bundle_id, endpoint)]
+  end
+
+  defp remove_bundle(id, bundle_id, %Endpoint{token: _}) do
     bundle = Server.show(Bundle, bundle_id)
     relay_group = Server.show(RelayGroup, id)
     remove_bundle(bundle, relay_group)

--- a/lib/cog_api/http/client.ex
+++ b/lib/cog_api/http/client.ex
@@ -158,12 +158,20 @@ defmodule CogApi.HTTP.Client do
     RelayGroups.update_memberships_by_id(:remove, relay_group_id, relay_ids, endpoint)
   end
 
-  def relay_group_add_bundles(relay_group_id, bundle_ids, %Endpoint{}=endpoint) do
-    RelayGroups.update_assignments(:add, relay_group_id, bundle_ids, endpoint)
+  def relay_group_add_bundles_by_name(relay_group_name, bundle_names, %Endpoint{}=endpoint) do
+    RelayGroups.update_assignments_by_name(:add, relay_group_name, bundle_names, endpoint)
   end
 
-  def relay_group_remove_bundles(relay_group_id, bundle_ids, %Endpoint{}=endpoint) do
-    RelayGroups.update_assignments(:remove, relay_group_id, bundle_ids, endpoint)
+  def relay_group_add_bundles_by_id(relay_group_id, bundle_ids, %Endpoint{}=endpoint) do
+    RelayGroups.update_assignments_by_id(:add, relay_group_id, bundle_ids, endpoint)
+  end
+
+  def relay_group_remove_bundles_by_name(relay_group_name, bundle_names, %Endpoint{}=endpoint) do
+    RelayGroups.update_assignments_by_name(:remove, relay_group_name, bundle_names, endpoint)
+  end
+
+  def relay_group_remove_bundles_by_id(relay_group_id, bundle_ids, %Endpoint{}=endpoint) do
+    RelayGroups.update_assignments_by_id(:remove, relay_group_id, bundle_ids, endpoint)
   end
 
   def role_index(endpoint) do

--- a/lib/cog_api/http/client.ex
+++ b/lib/cog_api/http/client.ex
@@ -142,12 +142,20 @@ defmodule CogApi.HTTP.Client do
     RelayGroups.delete(relay_group_id, endpoint)
   end
 
-  def relay_group_add_relays(relay_group_id, relay_ids, %Endpoint{}=endpoint) do
-    RelayGroups.update_memberships(:add, relay_group_id, relay_ids, endpoint)
+  def relay_group_add_relays_by_name(relay_group_name, relay_names, %Endpoint{}=endpoint) do
+    RelayGroups.update_memberships_by_name(:add, relay_group_name, relay_names, endpoint)
   end
 
-  def relay_group_remove_relays(relay_group_id, relay_ids, %Endpoint{}=endpoint) do
-    RelayGroups.update_memberships(:remove, relay_group_id, relay_ids, endpoint)
+  def relay_group_add_relays_by_id(relay_group_id, relay_ids, %Endpoint{}=endpoint) do
+    RelayGroups.update_memberships_by_id(:add, relay_group_id, relay_ids, endpoint)
+  end
+
+  def relay_group_remove_relays_by_name(relay_group_name, relay_names, %Endpoint{}=endpoint) do
+    RelayGroups.update_memberships_by_name(:remove, relay_group_name, relay_names, endpoint)
+  end
+
+  def relay_group_remove_relays_by_id(relay_group_id, relay_ids, %Endpoint{}=endpoint) do
+    RelayGroups.update_memberships_by_id(:remove, relay_group_id, relay_ids, endpoint)
   end
 
   def relay_group_add_bundles(relay_group_id, bundle_ids, %Endpoint{}=endpoint) do

--- a/lib/cog_api/http/client.ex
+++ b/lib/cog_api/http/client.ex
@@ -142,12 +142,12 @@ defmodule CogApi.HTTP.Client do
     RelayGroups.delete(relay_group_id, endpoint)
   end
 
-  def relay_group_add_relay(relay_group_id, relay_id, %Endpoint{}=endpoint) do
-    RelayGroups.update_memberships(:add, relay_group_id, relay_id, endpoint)
+  def relay_group_add_relays(relay_group_id, relay_ids, %Endpoint{}=endpoint) do
+    RelayGroups.update_memberships(:add, relay_group_id, relay_ids, endpoint)
   end
 
-  def relay_group_remove_relay(relay_group_id, relay_id, %Endpoint{}=endpoint) do
-    RelayGroups.update_memberships(:remove, relay_group_id, relay_id, endpoint)
+  def relay_group_remove_relays(relay_group_id, relay_ids, %Endpoint{}=endpoint) do
+    RelayGroups.update_memberships(:remove, relay_group_id, relay_ids, endpoint)
   end
 
   def relay_group_add_bundles(relay_group_id, bundle_ids, %Endpoint{}=endpoint) do

--- a/lib/cog_api/http/relay_groups.ex
+++ b/lib/cog_api/http/relay_groups.ex
@@ -38,30 +38,19 @@ defmodule CogApi.HTTP.RelayGroups do
     |> ApiResponse.format_delete("The relay group could not be deleted")
   end
 
-  def update_memberships(action, %{name: name}, %{relay: relay_name}, %Endpoint{}=endpoint) do
-    case get_group_relay(name, relay_name, endpoint) do
-      {:ok, relay, relay_group} ->
-        update_membership(relay_group.id, relay.id, action, endpoint)
-      error ->
-        error
+  def update_memberships(action, %{name: name}, %{relays: relay_names}, endpoint) when is_list(relay_names) do
+    with {:ok, relay_group} <- show(%{name: name}, endpoint),
+         {:ok, relay_ids}   <- get_relay_ids(relay_names, endpoint) do
+      update_memberships(action, relay_group.id, relay_ids, endpoint)
     end
   end
-  def update_memberships(action, relay_group_id, relay_id, %Endpoint{}=endpoint) do
-    update_membership(relay_group_id, relay_id, action, endpoint)
-  end
-
-  defp get_group_relay(name, relay_name, endpoint) do
-    with {:ok, relay} <- Base.get_by(endpoint, "relays", name: relay_name)
-        |> ApiResponse.format(%{"relay" => CogApi.Resources.Relay.format}),
-      {:ok, relay_group} <- show(%{name: name}, endpoint),
-      do: {:ok, relay, relay_group}
-  end
-
-  defp update_membership(relay_group_id, relay_id, action, endpoint) do
+  def update_memberships(action, relay_group_id, relay_ids, endpoint) when is_list(relay_ids) do
     path = "relay_groups/#{relay_group_id}/relays"
-    Base.post(endpoint, path, %{relays: %{action =>  [relay_id]}})
+    Base.post(endpoint, path, %{relays: %{action => relay_ids}})
     |> ApiResponse.format(%{"relay_group" => RelayGroup.format})
   end
+  def update_memberships(action, relay_group_id, relay_id, endpoint) when is_binary(relay_id),
+    do: update_memberships(action, relay_group_id, [relay_id], endpoint)
 
   def update_assignments(action, %{name: name}, %{bundles: bundle_names}, endpoint) when is_list(bundle_names) do
     with {:ok, relay_group} <- show(%{name: name}, endpoint),
@@ -77,6 +66,26 @@ defmodule CogApi.HTTP.RelayGroups do
   def update_assignments(action, relay_group_id, bundle_id, endpoint) when is_binary(bundle_id),
     do: update_assignments(action, relay_group_id, [bundle_id], endpoint)
 
+  defp get_relay_ids(relay_names, endpoint) when is_list(relay_names) do
+    get_relay_id = fn(name, acc, endpoint) ->
+      case Base.get_by(endpoint, "relays", name: name)
+      |> ApiResponse.format(%{"relay" => CogApi.Resources.Relay.format}) do
+        {:ok, relay} ->
+          {:cont, [relay.id | acc]}
+        error ->
+          {:halt, error}
+      end
+    end
+
+    case Enum.reduce_while(relay_names, [], &get_relay_id.(&1, &2, endpoint)) do
+      relay_ids when is_list(relay_ids) ->
+        {:ok, relay_ids}
+      error ->
+        error
+    end
+  end
+  defp get_relay_ids(relay_name, endpoint),
+    do: get_relay_ids([relay_name], endpoint)
 
   defp get_bundle_ids(bundle_names, endpoint) when is_list(bundle_names) do
     get_bundle_id = fn(name, acc, endpoint) ->

--- a/lib/cog_api/http/relay_groups.ex
+++ b/lib/cog_api/http/relay_groups.ex
@@ -53,19 +53,20 @@ defmodule CogApi.HTTP.RelayGroups do
     |> ApiResponse.format(%{"relay_group" => RelayGroup.format})
   end
 
-  def update_assignments(action, %{name: name}, %{bundles: bundle_names}, endpoint) when is_list(bundle_names) do
-    with {:ok, relay_group} <- show(%{name: name}, endpoint),
+  def update_assignments_by_name(action, relay_group_name, bundle_names, endpoint) do
+    bundle_names = List.wrap(bundle_names)
+    with {:ok, relay_group} <- show(%{name: relay_group_name}, endpoint),
          {:ok, bundle_ids}  <- get_bundle_ids(bundle_names, endpoint) do
-      update_assignments(action, relay_group.id, bundle_ids, endpoint)
+      update_assignments_by_id(action, relay_group.id, bundle_ids, endpoint)
     end
   end
-  def update_assignments(action, relay_group_id, bundle_ids, endpoint) when is_list(bundle_ids) do
+
+  def update_assignments_by_id(action, relay_group_id, bundle_ids, endpoint) do
+    bundle_ids = List.wrap(bundle_ids)
     path = "relay_groups/#{relay_group_id}/bundles"
     Base.post(endpoint, path, %{bundles: %{action => bundle_ids}})
     |> ApiResponse.format(%{"relay_group" => RelayGroup.format})
   end
-  def update_assignments(action, relay_group_id, bundle_id, endpoint) when is_binary(bundle_id),
-    do: update_assignments(action, relay_group_id, [bundle_id], endpoint)
 
   defp get_relay_ids(relay_names, endpoint) when is_list(relay_names) do
     get_relay_id = fn(name, acc, endpoint) ->

--- a/lib/cog_api/http/relay_groups.ex
+++ b/lib/cog_api/http/relay_groups.ex
@@ -38,19 +38,20 @@ defmodule CogApi.HTTP.RelayGroups do
     |> ApiResponse.format_delete("The relay group could not be deleted")
   end
 
-  def update_memberships(action, %{name: name}, %{relays: relay_names}, endpoint) when is_list(relay_names) do
-    with {:ok, relay_group} <- show(%{name: name}, endpoint),
+  def update_memberships_by_name(action, relay_group_name, relay_names, endpoint) do
+    relay_names = List.wrap(relay_names)
+    with {:ok, relay_group} <- show(%{name: relay_group_name}, endpoint),
          {:ok, relay_ids}   <- get_relay_ids(relay_names, endpoint) do
-      update_memberships(action, relay_group.id, relay_ids, endpoint)
+      update_memberships_by_id(action, relay_group.id, relay_ids, endpoint)
     end
   end
-  def update_memberships(action, relay_group_id, relay_ids, endpoint) when is_list(relay_ids) do
+
+  def update_memberships_by_id(action, relay_group_id, relay_ids, endpoint) do
+    relay_ids = List.wrap(relay_ids)
     path = "relay_groups/#{relay_group_id}/relays"
     Base.post(endpoint, path, %{relays: %{action => relay_ids}})
     |> ApiResponse.format(%{"relay_group" => RelayGroup.format})
   end
-  def update_memberships(action, relay_group_id, relay_id, endpoint) when is_binary(relay_id),
-    do: update_memberships(action, relay_group_id, [relay_id], endpoint)
 
   def update_assignments(action, %{name: name}, %{bundles: bundle_names}, endpoint) when is_list(bundle_names) do
     with {:ok, relay_group} <- show(%{name: name}, endpoint),

--- a/test/fixtures/vcr/relay_group_add_relay.json
+++ b/test/fixtures/vcr/relay_group_add_relay.json
@@ -11,14 +11,14 @@
       "url": "http://localhost:4000/v1/token"
     },
     "response": {
-      "body": "{\"token\":{\"value\":\"w05n5iZL4peQoZ1gibP1MR1TgvSTXrIwZzCIJYRjR+0=\"}}",
+      "body": "{\"token\":{\"value\":\"LyyMafHLfN/7g6zC/Pat5RIBRXbXu7JIyTwXKhAs0kA=\"}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 17:56:51 GMT",
+        "date": "Tue, 19 Apr 2016 18:01:16 GMT",
         "content-length": "66",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "gqoipfsg7rujlqvus4dtockcclbekntm"
+        "x-request-id": "grt42kgb0k9fvpqedpgnj6903g425u1j"
       },
       "status_code": 201,
       "type": "ok"
@@ -28,7 +28,7 @@
     "request": {
       "body": "{\"relay\":{\"token\":\"1234\",\"name\":\"relayyy\"}}",
       "headers": {
-        "authorization": "token w05n5iZL4peQoZ1gibP1MR1TgvSTXrIwZzCIJYRjR+0=",
+        "authorization": "token LyyMafHLfN/7g6zC/Pat5RIBRXbXu7JIyTwXKhAs0kA=",
         "Content-Type": "application/json"
       },
       "method": "post",
@@ -37,15 +37,15 @@
       "url": "http://localhost:4000/v1/relays"
     },
     "response": {
-      "body": "{\"relay\":{\"updated_at\":\"2016-04-18T17:56:52Z\",\"name\":\"relayyy\",\"inserted_at\":\"2016-04-18T17:56:52Z\",\"id\":\"1c78461e-8e47-48c2-bd99-b4cf6aa1f77d\",\"groups\":[],\"enabled\":false,\"description\":null}}",
+      "body": "{\"relay\":{\"updated_at\":\"2016-04-19T18:01:18Z\",\"name\":\"relayyy\",\"inserted_at\":\"2016-04-19T18:01:18Z\",\"id\":\"3aaaee09-a4cb-491f-9e8f-b68a085b704b\",\"groups\":[],\"enabled\":false,\"description\":null}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 17:56:52 GMT",
+        "date": "Tue, 19 Apr 2016 18:01:17 GMT",
         "content-length": "192",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "nqlai7fferjmdb719ol8kb0d2n2acq5d",
-        "location": "/v1/relays/1c78461e-8e47-48c2-bd99-b4cf6aa1f77d"
+        "x-request-id": "k2ob1nfm4s3q6ng0vnbhgaa08ri81goi",
+        "location": "/v1/relays/3aaaee09-a4cb-491f-9e8f-b68a085b704b"
       },
       "status_code": 201,
       "type": "ok"
@@ -55,7 +55,7 @@
     "request": {
       "body": "{\"relay_group\":{\"name\":\"groupyy\"}}",
       "headers": {
-        "authorization": "token w05n5iZL4peQoZ1gibP1MR1TgvSTXrIwZzCIJYRjR+0=",
+        "authorization": "token LyyMafHLfN/7g6zC/Pat5RIBRXbXu7JIyTwXKhAs0kA=",
         "Content-Type": "application/json"
       },
       "method": "post",
@@ -64,15 +64,15 @@
       "url": "http://localhost:4000/v1/relay_groups"
     },
     "response": {
-      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-18T17:56:52Z\",\"relays\":[],\"name\":\"groupyy\",\"inserted_at\":\"2016-04-18T17:56:52Z\",\"id\":\"4794154d-6eb9-402a-8b1b-ef44d293ed71\",\"bundles\":[]}}",
+      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-19T18:01:18Z\",\"relays\":[],\"name\":\"groupyy\",\"inserted_at\":\"2016-04-19T18:01:18Z\",\"id\":\"2ed3b840-2642-47c8-97df-2ec50017d92e\",\"bundles\":[]}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 17:56:52 GMT",
+        "date": "Tue, 19 Apr 2016 18:01:17 GMT",
         "content-length": "176",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "bh08iv73art36ro9tnb1bhu7b3sb7b3l",
-        "location": "/v1/groups/4794154d-6eb9-402a-8b1b-ef44d293ed71"
+        "x-request-id": "tm6otikk7pf25mcfpkvfihf7dcdk2p4e",
+        "location": "/v1/groups/2ed3b840-2642-47c8-97df-2ec50017d92e"
       },
       "status_code": 201,
       "type": "ok"
@@ -80,25 +80,25 @@
   },
   {
     "request": {
-      "body": "{\"relays\":{\"add\":[\"1c78461e-8e47-48c2-bd99-b4cf6aa1f77d\"]}}",
+      "body": "{\"relays\":{\"add\":[\"3aaaee09-a4cb-491f-9e8f-b68a085b704b\"]}}",
       "headers": {
-        "authorization": "token w05n5iZL4peQoZ1gibP1MR1TgvSTXrIwZzCIJYRjR+0=",
+        "authorization": "token LyyMafHLfN/7g6zC/Pat5RIBRXbXu7JIyTwXKhAs0kA=",
         "Content-Type": "application/json"
       },
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://localhost:4000/v1/relay_groups/4794154d-6eb9-402a-8b1b-ef44d293ed71/relays"
+      "url": "http://localhost:4000/v1/relay_groups/2ed3b840-2642-47c8-97df-2ec50017d92e/relays"
     },
     "response": {
-      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-18T17:56:52Z\",\"relays\":[{\"updated_at\":\"2016-04-18T17:56:52Z\",\"name\":\"relayyy\",\"inserted_at\":\"2016-04-18T17:56:52Z\",\"id\":\"1c78461e-8e47-48c2-bd99-b4cf6aa1f77d\",\"enabled\":false,\"description\":null}],\"name\":\"groupyy\",\"inserted_at\":\"2016-04-18T17:56:52Z\",\"id\":\"4794154d-6eb9-402a-8b1b-ef44d293ed71\",\"bundles\":[]}}",
+      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-19T18:01:18Z\",\"relays\":[{\"updated_at\":\"2016-04-19T18:01:18Z\",\"name\":\"relayyy\",\"inserted_at\":\"2016-04-19T18:01:18Z\",\"id\":\"3aaaee09-a4cb-491f-9e8f-b68a085b704b\",\"enabled\":false,\"description\":null}],\"name\":\"groupyy\",\"inserted_at\":\"2016-04-19T18:01:18Z\",\"id\":\"2ed3b840-2642-47c8-97df-2ec50017d92e\",\"bundles\":[]}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 17:56:52 GMT",
+        "date": "Tue, 19 Apr 2016 18:01:17 GMT",
         "content-length": "346",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "7d7lseg52puq2s5vnahfq19l0c6l8evg"
+        "x-request-id": "0j2paubep7nfj7ekmh1j5s555bpn48qg"
       },
       "status_code": 200,
       "type": "ok"

--- a/test/fixtures/vcr/relay_group_add_relay_failure.json
+++ b/test/fixtures/vcr/relay_group_add_relay_failure.json
@@ -11,14 +11,14 @@
       "url": "http://localhost:4000/v1/token"
     },
     "response": {
-      "body": "{\"token\":{\"value\":\"J7Hvf/xBXKfOnyPgreOUSa+UaT29LWpjntu1EtylfOY=\"}}",
+      "body": "{\"token\":{\"value\":\"Wtwk8DqS8reQyuF2rL0vWyTHZJt0cebUYdX6vngIS84=\"}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Fri, 15 Apr 2016 01:28:31 GMT",
+        "date": "Tue, 19 Apr 2016 18:07:34 GMT",
         "content-length": "66",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "6hljtqqd1gfhcrt55aigsui5s7sh5skg"
+        "x-request-id": "i0acv1ci30irfca8tqultffu0q7rq1sc"
       },
       "status_code": 201,
       "type": "ok"
@@ -28,7 +28,7 @@
     "request": {
       "body": "{\"relay_group\":{\"name\":\"my_relays\"}}",
       "headers": {
-        "authorization": "token J7Hvf/xBXKfOnyPgreOUSa+UaT29LWpjntu1EtylfOY=",
+        "authorization": "token Wtwk8DqS8reQyuF2rL0vWyTHZJt0cebUYdX6vngIS84=",
         "Content-Type": "application/json"
       },
       "method": "post",
@@ -37,15 +37,15 @@
       "url": "http://localhost:4000/v1/relay_groups"
     },
     "response": {
-      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-15T01:28:32Z\",\"relays\":[],\"name\":\"my_relays\",\"inserted_at\":\"2016-04-15T01:28:32Z\",\"id\":\"de391dc3-5d0e-472e-88a5-69604e6b3e26\",\"bundles\":[]}}",
+      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-19T18:07:35Z\",\"relays\":[],\"name\":\"my_relays\",\"inserted_at\":\"2016-04-19T18:07:35Z\",\"id\":\"4729f7fe-da9d-446c-9bf7-1adaeec829f5\",\"bundles\":[]}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Fri, 15 Apr 2016 01:28:31 GMT",
+        "date": "Tue, 19 Apr 2016 18:07:34 GMT",
         "content-length": "178",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "462iv0ll88fov46i5p4ucrjqv2q8i6c0",
-        "location": "/v1/groups/de391dc3-5d0e-472e-88a5-69604e6b3e26"
+        "x-request-id": "b0lu8hmnpd5k06jptn8094sudmths2rl",
+        "location": "/v1/groups/4729f7fe-da9d-446c-9bf7-1adaeec829f5"
       },
       "status_code": 201,
       "type": "ok"
@@ -55,7 +55,59 @@
     "request": {
       "body": "",
       "headers": {
-        "authorization": "token J7Hvf/xBXKfOnyPgreOUSa+UaT29LWpjntu1EtylfOY=",
+        "authorization": "token Wtwk8DqS8reQyuF2rL0vWyTHZJt0cebUYdX6vngIS84=",
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/relay_groups"
+    },
+    "response": {
+      "body": "{\"relay_groups\":[{\"updated_at\":\"2016-04-19T18:06:58Z\",\"relays\":[],\"name\":\"myrelays\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"f6fe6343-02d9-4ca2-b27c-7beb3663bb9e\",\"bundles\":[]},{\"updated_at\":\"2016-04-19T18:07:35Z\",\"relays\":[],\"name\":\"my_relays\",\"inserted_at\":\"2016-04-19T18:07:35Z\",\"id\":\"4729f7fe-da9d-446c-9bf7-1adaeec829f5\",\"bundles\":[]}]}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 19 Apr 2016 18:07:34 GMT",
+        "content-length": "343",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "84ii9a3o94ljp2mea5dcufbpsvnig045"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "token Wtwk8DqS8reQyuF2rL0vWyTHZJt0cebUYdX6vngIS84=",
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/relay_groups/4729f7fe-da9d-446c-9bf7-1adaeec829f5"
+    },
+    "response": {
+      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-19T18:07:35Z\",\"relays\":[],\"name\":\"my_relays\",\"inserted_at\":\"2016-04-19T18:07:35Z\",\"id\":\"4729f7fe-da9d-446c-9bf7-1adaeec829f5\",\"bundles\":[]}}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 19 Apr 2016 18:07:34 GMT",
+        "content-length": "178",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "urp6s9ou8roc884emssaaks9r9i3jc6e"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "token Wtwk8DqS8reQyuF2rL0vWyTHZJt0cebUYdX6vngIS84=",
         "Accept": "application/json"
       },
       "method": "get",
@@ -64,14 +116,14 @@
       "url": "http://localhost:4000/v1/relays"
     },
     "response": {
-      "body": "{\"relays\":[]}",
+      "body": "{\"relays\":[{\"updated_at\":\"2016-04-19T18:06:58Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"044edd09-9a27-4bda-a813-78eaae85ee09\",\"groups\":[],\"enabled\":false,\"description\":null}]}",
       "headers": {
         "server": "Cowboy",
-        "date": "Fri, 15 Apr 2016 01:28:31 GMT",
-        "content-length": "13",
+        "date": "Tue, 19 Apr 2016 18:07:34 GMT",
+        "content-length": "194",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "s8353ukj2ua055ut9pkt1eh89svkn8b0"
+        "x-request-id": "v5livke88otveh8e0fmk97itloh28pot"
       },
       "status_code": 200,
       "type": "ok"

--- a/test/fixtures/vcr/relay_group_remove_relay_failure.json
+++ b/test/fixtures/vcr/relay_group_remove_relay_failure.json
@@ -11,14 +11,14 @@
       "url": "http://localhost:4000/v1/token"
     },
     "response": {
-      "body": "{\"token\":{\"value\":\"/sv6iyiOqVsp1zOEYeGA2T/SNOK7vH6Mr9YoELHI4nI=\"}}",
+      "body": "{\"token\":{\"value\":\"Z++5syxo1DzEaD9arOfSm+5ApfhMV5k0Yf8EwiB+1RI=\"}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Fri, 15 Apr 2016 01:33:47 GMT",
+        "date": "Tue, 19 Apr 2016 18:08:04 GMT",
         "content-length": "66",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "98kua3u6btgd2eqglmcfj12b9amtp3v7"
+        "x-request-id": "8koo05a634dn8alv1o2e37m6k97fu4k3"
       },
       "status_code": 201,
       "type": "ok"
@@ -28,7 +28,7 @@
     "request": {
       "body": "{\"relay_group\":{\"name\":\"my_relay_group\"}}",
       "headers": {
-        "authorization": "token /sv6iyiOqVsp1zOEYeGA2T/SNOK7vH6Mr9YoELHI4nI=",
+        "authorization": "token Z++5syxo1DzEaD9arOfSm+5ApfhMV5k0Yf8EwiB+1RI=",
         "Content-Type": "application/json"
       },
       "method": "post",
@@ -37,15 +37,15 @@
       "url": "http://localhost:4000/v1/relay_groups"
     },
     "response": {
-      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-15T01:33:48Z\",\"relays\":[],\"name\":\"my_relay_group\",\"inserted_at\":\"2016-04-15T01:33:48Z\",\"id\":\"6f757dcb-05e8-49d6-affa-7d1ae7cdf346\",\"bundles\":[]}}",
+      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-19T18:08:04Z\",\"relays\":[],\"name\":\"my_relay_group\",\"inserted_at\":\"2016-04-19T18:08:04Z\",\"id\":\"4301aed0-ee23-425b-b817-d42e31e45e71\",\"bundles\":[]}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Fri, 15 Apr 2016 01:33:47 GMT",
+        "date": "Tue, 19 Apr 2016 18:08:04 GMT",
         "content-length": "183",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "2v3v3rqpnd1v96psc0l4g7hcn5up3r34",
-        "location": "/v1/groups/6f757dcb-05e8-49d6-affa-7d1ae7cdf346"
+        "x-request-id": "b1dqffutmve9tkhskv94g6uh0888qe7v",
+        "location": "/v1/groups/4301aed0-ee23-425b-b817-d42e31e45e71"
       },
       "status_code": 201,
       "type": "ok"
@@ -55,7 +55,59 @@
     "request": {
       "body": "",
       "headers": {
-        "authorization": "token /sv6iyiOqVsp1zOEYeGA2T/SNOK7vH6Mr9YoELHI4nI=",
+        "authorization": "token Z++5syxo1DzEaD9arOfSm+5ApfhMV5k0Yf8EwiB+1RI=",
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/relay_groups"
+    },
+    "response": {
+      "body": "{\"relay_groups\":[{\"updated_at\":\"2016-04-19T18:06:58Z\",\"relays\":[],\"name\":\"myrelays\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"f6fe6343-02d9-4ca2-b27c-7beb3663bb9e\",\"bundles\":[]},{\"updated_at\":\"2016-04-19T18:07:35Z\",\"relays\":[],\"name\":\"my_relays\",\"inserted_at\":\"2016-04-19T18:07:35Z\",\"id\":\"4729f7fe-da9d-446c-9bf7-1adaeec829f5\",\"bundles\":[]},{\"updated_at\":\"2016-04-19T18:08:04Z\",\"relays\":[],\"name\":\"my_relay_group\",\"inserted_at\":\"2016-04-19T18:08:04Z\",\"id\":\"4301aed0-ee23-425b-b817-d42e31e45e71\",\"bundles\":[]}]}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 19 Apr 2016 18:08:04 GMT",
+        "content-length": "511",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "qef6gp5k7b8aeb4kpvvud562bu6q0b13"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "token Z++5syxo1DzEaD9arOfSm+5ApfhMV5k0Yf8EwiB+1RI=",
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/relay_groups/4301aed0-ee23-425b-b817-d42e31e45e71"
+    },
+    "response": {
+      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-19T18:08:04Z\",\"relays\":[],\"name\":\"my_relay_group\",\"inserted_at\":\"2016-04-19T18:08:04Z\",\"id\":\"4301aed0-ee23-425b-b817-d42e31e45e71\",\"bundles\":[]}}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 19 Apr 2016 18:08:04 GMT",
+        "content-length": "183",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "8n280ccm0c7kevv64mtdgii401kejelv"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "token Z++5syxo1DzEaD9arOfSm+5ApfhMV5k0Yf8EwiB+1RI=",
         "Accept": "application/json"
       },
       "method": "get",
@@ -64,14 +116,14 @@
       "url": "http://localhost:4000/v1/relays"
     },
     "response": {
-      "body": "{\"relays\":[]}",
+      "body": "{\"relays\":[{\"updated_at\":\"2016-04-19T18:06:58Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"044edd09-9a27-4bda-a813-78eaae85ee09\",\"groups\":[],\"enabled\":false,\"description\":null}]}",
       "headers": {
         "server": "Cowboy",
-        "date": "Fri, 15 Apr 2016 01:33:47 GMT",
-        "content-length": "13",
+        "date": "Tue, 19 Apr 2016 18:08:04 GMT",
+        "content-length": "194",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "erft2j4onaq4ak5nhenq9idbrhbe7gmk"
+        "x-request-id": "ml3j7fcpggn9k3di7rlre2goe3uhfegu"
       },
       "status_code": 200,
       "type": "ok"

--- a/test/fixtures/vcr/relay_group_remove_with_name.json
+++ b/test/fixtures/vcr/relay_group_remove_with_name.json
@@ -11,14 +11,14 @@
       "url": "http://localhost:4000/v1/token"
     },
     "response": {
-      "body": "{\"token\":{\"value\":\"Po7igIilM9Gdo1hYs94+wdArFWTVExkXGQYNJObu6Gs=\"}}",
+      "body": "{\"token\":{\"value\":\"GwWr/LQccJgaEHJeCAaxBHfPmcXowg/NeR970sHRknA=\"}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 18:11:01 GMT",
+        "date": "Tue, 19 Apr 2016 18:06:56 GMT",
         "content-length": "66",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "t63j2ukp2at35qf64gbr4jeoirm8hacp"
+        "x-request-id": "clvarilm2vqiq9pt9e8ncj9eovth6acn"
       },
       "status_code": 201,
       "type": "ok"
@@ -28,7 +28,7 @@
     "request": {
       "body": "{\"relay\":{\"token\":\"1234\",\"name\":\"relay2\"}}",
       "headers": {
-        "authorization": "token Po7igIilM9Gdo1hYs94+wdArFWTVExkXGQYNJObu6Gs=",
+        "authorization": "token GwWr/LQccJgaEHJeCAaxBHfPmcXowg/NeR970sHRknA=",
         "Content-Type": "application/json"
       },
       "method": "post",
@@ -37,15 +37,15 @@
       "url": "http://localhost:4000/v1/relays"
     },
     "response": {
-      "body": "{\"relay\":{\"updated_at\":\"2016-04-18T18:11:02Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"8b58d629-0908-4f6e-9dd9-82d112378fa0\",\"groups\":[],\"enabled\":false,\"description\":null}}",
+      "body": "{\"relay\":{\"updated_at\":\"2016-04-19T18:06:58Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"044edd09-9a27-4bda-a813-78eaae85ee09\",\"groups\":[],\"enabled\":false,\"description\":null}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 18:11:02 GMT",
+        "date": "Tue, 19 Apr 2016 18:06:58 GMT",
         "content-length": "191",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "e9aqhjdoma4nhuhgv2p1voo4vj6nbdpv",
-        "location": "/v1/relays/8b58d629-0908-4f6e-9dd9-82d112378fa0"
+        "x-request-id": "v7n795cpo2sis4in8c39mq4nds48r3nt",
+        "location": "/v1/relays/044edd09-9a27-4bda-a813-78eaae85ee09"
       },
       "status_code": 201,
       "type": "ok"
@@ -55,7 +55,7 @@
     "request": {
       "body": "{\"relay_group\":{\"name\":\"myrelays\"}}",
       "headers": {
-        "authorization": "token Po7igIilM9Gdo1hYs94+wdArFWTVExkXGQYNJObu6Gs=",
+        "authorization": "token GwWr/LQccJgaEHJeCAaxBHfPmcXowg/NeR970sHRknA=",
         "Content-Type": "application/json"
       },
       "method": "post",
@@ -64,15 +64,15 @@
       "url": "http://localhost:4000/v1/relay_groups"
     },
     "response": {
-      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-18T18:11:02Z\",\"relays\":[],\"name\":\"myrelays\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"fbdafeb8-6764-4e91-9859-3b168366092c\",\"bundles\":[]}}",
+      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-19T18:06:58Z\",\"relays\":[],\"name\":\"myrelays\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"f6fe6343-02d9-4ca2-b27c-7beb3663bb9e\",\"bundles\":[]}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 18:11:02 GMT",
+        "date": "Tue, 19 Apr 2016 18:06:58 GMT",
         "content-length": "177",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "tt8ltmm1uab5d2v89tt7c7e60f45pacf",
-        "location": "/v1/groups/fbdafeb8-6764-4e91-9859-3b168366092c"
+        "x-request-id": "2cevneu3c10b29g01po2ibm8cfo1vm62",
+        "location": "/v1/groups/f6fe6343-02d9-4ca2-b27c-7beb3663bb9e"
       },
       "status_code": 201,
       "type": "ok"
@@ -80,25 +80,25 @@
   },
   {
     "request": {
-      "body": "{\"relays\":{\"add\":[\"8b58d629-0908-4f6e-9dd9-82d112378fa0\"]}}",
+      "body": "{\"relays\":{\"add\":[\"044edd09-9a27-4bda-a813-78eaae85ee09\"]}}",
       "headers": {
-        "authorization": "token Po7igIilM9Gdo1hYs94+wdArFWTVExkXGQYNJObu6Gs=",
+        "authorization": "token GwWr/LQccJgaEHJeCAaxBHfPmcXowg/NeR970sHRknA=",
         "Content-Type": "application/json"
       },
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://localhost:4000/v1/relay_groups/fbdafeb8-6764-4e91-9859-3b168366092c/relays"
+      "url": "http://localhost:4000/v1/relay_groups/f6fe6343-02d9-4ca2-b27c-7beb3663bb9e/relays"
     },
     "response": {
-      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-18T18:11:02Z\",\"relays\":[{\"updated_at\":\"2016-04-18T18:11:02Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"8b58d629-0908-4f6e-9dd9-82d112378fa0\",\"enabled\":false,\"description\":null}],\"name\":\"myrelays\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"fbdafeb8-6764-4e91-9859-3b168366092c\",\"bundles\":[]}}",
+      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-19T18:06:58Z\",\"relays\":[{\"updated_at\":\"2016-04-19T18:06:58Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"044edd09-9a27-4bda-a813-78eaae85ee09\",\"enabled\":false,\"description\":null}],\"name\":\"myrelays\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"f6fe6343-02d9-4ca2-b27c-7beb3663bb9e\",\"bundles\":[]}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 18:11:02 GMT",
+        "date": "Tue, 19 Apr 2016 18:06:58 GMT",
         "content-length": "346",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "8qker2vtgq5m1p5ln2i1p59qk7l8daju"
+        "x-request-id": "5f32lom1e64gj0c80ua4h3blrohldhtd"
       },
       "status_code": 200,
       "type": "ok"
@@ -108,7 +108,59 @@
     "request": {
       "body": "",
       "headers": {
-        "authorization": "token Po7igIilM9Gdo1hYs94+wdArFWTVExkXGQYNJObu6Gs=",
+        "authorization": "token GwWr/LQccJgaEHJeCAaxBHfPmcXowg/NeR970sHRknA=",
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/relay_groups"
+    },
+    "response": {
+      "body": "{\"relay_groups\":[{\"updated_at\":\"2016-04-19T18:06:58Z\",\"relays\":[{\"updated_at\":\"2016-04-19T18:06:58Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"044edd09-9a27-4bda-a813-78eaae85ee09\",\"enabled\":false,\"description\":null}],\"name\":\"myrelays\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"f6fe6343-02d9-4ca2-b27c-7beb3663bb9e\",\"bundles\":[]}]}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 19 Apr 2016 18:06:58 GMT",
+        "content-length": "349",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "hues3238hm4h9n0d6s481462mf3rmliq"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "token GwWr/LQccJgaEHJeCAaxBHfPmcXowg/NeR970sHRknA=",
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/relay_groups/f6fe6343-02d9-4ca2-b27c-7beb3663bb9e"
+    },
+    "response": {
+      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-19T18:06:58Z\",\"relays\":[{\"updated_at\":\"2016-04-19T18:06:58Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"044edd09-9a27-4bda-a813-78eaae85ee09\",\"enabled\":false,\"description\":null}],\"name\":\"myrelays\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"f6fe6343-02d9-4ca2-b27c-7beb3663bb9e\",\"bundles\":[]}}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 19 Apr 2016 18:06:58 GMT",
+        "content-length": "346",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "cs6gdhj2f8kb8sq53n3m9854h39e1bkp"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "token GwWr/LQccJgaEHJeCAaxBHfPmcXowg/NeR970sHRknA=",
         "Accept": "application/json"
       },
       "method": "get",
@@ -117,14 +169,14 @@
       "url": "http://localhost:4000/v1/relays"
     },
     "response": {
-      "body": "{\"relays\":[{\"updated_at\":\"2016-04-18T13:46:17Z\",\"name\":\"test_relay\",\"inserted_at\":\"2016-04-18T13:46:17Z\",\"id\":\"a82cf944-5135-4311-affe-8f5db7add952\",\"groups\":[],\"enabled\":true,\"description\":null},{\"updated_at\":\"2016-04-18T17:56:15Z\",\"name\":\"relay1\",\"inserted_at\":\"2016-04-18T17:56:15Z\",\"id\":\"01c8d9b4-be40-4035-bce9-f2a5d2e0e7b3\",\"groups\":[],\"enabled\":false,\"description\":null},{\"updated_at\":\"2016-04-18T17:56:52Z\",\"name\":\"relayyy\",\"inserted_at\":\"2016-04-18T17:56:52Z\",\"id\":\"1c78461e-8e47-48c2-bd99-b4cf6aa1f77d\",\"groups\":[],\"enabled\":false,\"description\":null},{\"updated_at\":\"2016-04-18T18:03:18Z\",\"name\":\"Remove\",\"inserted_at\":\"2016-04-18T18:03:18Z\",\"id\":\"98309b21-0e90-4984-b4ab-b259dcb16f64\",\"groups\":[],\"enabled\":false,\"description\":null},{\"updated_at\":\"2016-04-18T18:11:02Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"8b58d629-0908-4f6e-9dd9-82d112378fa0\",\"groups\":[{\"updated_at\":\"2016-04-18T18:11:02Z\",\"name\":\"myrelays\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"fbdafeb8-6764-4e91-9859-3b168366092c\"}],\"enabled\":false,\"description\":null}]}",
+      "body": "{\"relays\":[{\"updated_at\":\"2016-04-19T18:06:58Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"044edd09-9a27-4bda-a813-78eaae85ee09\",\"groups\":[{\"updated_at\":\"2016-04-19T18:06:58Z\",\"name\":\"myrelays\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"f6fe6343-02d9-4ca2-b27c-7beb3663bb9e\"}],\"enabled\":false,\"description\":null}]}",
       "headers": {
         "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 18:11:02 GMT",
-        "content-length": "1062",
+        "date": "Tue, 19 Apr 2016 18:06:58 GMT",
+        "content-length": "330",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "jcfaa8e2m00qfttvc0hhhldg8kgj55b6"
+        "x-request-id": "m8n3mu2hlno3303ent50grsufctps97k"
       },
       "status_code": 200,
       "type": "ok"
@@ -134,23 +186,23 @@
     "request": {
       "body": "",
       "headers": {
-        "authorization": "token Po7igIilM9Gdo1hYs94+wdArFWTVExkXGQYNJObu6Gs=",
+        "authorization": "token GwWr/LQccJgaEHJeCAaxBHfPmcXowg/NeR970sHRknA=",
         "Accept": "application/json"
       },
       "method": "get",
       "options": [],
       "request_body": "",
-      "url": "http://localhost:4000/v1/relays/8b58d629-0908-4f6e-9dd9-82d112378fa0"
+      "url": "http://localhost:4000/v1/relays/044edd09-9a27-4bda-a813-78eaae85ee09"
     },
     "response": {
-      "body": "{\"relay\":{\"updated_at\":\"2016-04-18T18:11:02Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"8b58d629-0908-4f6e-9dd9-82d112378fa0\",\"groups\":[{\"updated_at\":\"2016-04-18T18:11:02Z\",\"name\":\"myrelays\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"fbdafeb8-6764-4e91-9859-3b168366092c\"}],\"enabled\":false,\"description\":null}}",
+      "body": "{\"relay\":{\"updated_at\":\"2016-04-19T18:06:58Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"044edd09-9a27-4bda-a813-78eaae85ee09\",\"groups\":[{\"updated_at\":\"2016-04-19T18:06:58Z\",\"name\":\"myrelays\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"f6fe6343-02d9-4ca2-b27c-7beb3663bb9e\"}],\"enabled\":false,\"description\":null}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 18:11:02 GMT",
+        "date": "Tue, 19 Apr 2016 18:06:58 GMT",
         "content-length": "327",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "4o4iukrji2aj6gonjalsa9hbaage215d"
+        "x-request-id": "e6v62anbgri7booqornam9vonh6nejgg"
       },
       "status_code": 200,
       "type": "ok"
@@ -158,77 +210,25 @@
   },
   {
     "request": {
-      "body": "",
+      "body": "{\"relays\":{\"remove\":[\"044edd09-9a27-4bda-a813-78eaae85ee09\"]}}",
       "headers": {
-        "authorization": "token Po7igIilM9Gdo1hYs94+wdArFWTVExkXGQYNJObu6Gs=",
-        "Accept": "application/json"
-      },
-      "method": "get",
-      "options": [],
-      "request_body": "",
-      "url": "http://localhost:4000/v1/relay_groups"
-    },
-    "response": {
-      "body": "{\"relay_groups\":[{\"updated_at\":\"2016-04-18T18:11:02Z\",\"relays\":[{\"updated_at\":\"2016-04-18T18:11:02Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"8b58d629-0908-4f6e-9dd9-82d112378fa0\",\"enabled\":false,\"description\":null}],\"name\":\"myrelays\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"fbdafeb8-6764-4e91-9859-3b168366092c\",\"bundles\":[]}]}",
-      "headers": {
-        "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 18:11:02 GMT",
-        "content-length": "349",
-        "content-type": "application/json; charset=utf-8",
-        "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "4plq87sjhd9k56c8crunakg12v6tdbg2"
-      },
-      "status_code": 200,
-      "type": "ok"
-    }
-  },
-  {
-    "request": {
-      "body": "",
-      "headers": {
-        "authorization": "token Po7igIilM9Gdo1hYs94+wdArFWTVExkXGQYNJObu6Gs=",
-        "Accept": "application/json"
-      },
-      "method": "get",
-      "options": [],
-      "request_body": "",
-      "url": "http://localhost:4000/v1/relay_groups/fbdafeb8-6764-4e91-9859-3b168366092c"
-    },
-    "response": {
-      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-18T18:11:02Z\",\"relays\":[{\"updated_at\":\"2016-04-18T18:11:02Z\",\"name\":\"relay2\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"8b58d629-0908-4f6e-9dd9-82d112378fa0\",\"enabled\":false,\"description\":null}],\"name\":\"myrelays\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"fbdafeb8-6764-4e91-9859-3b168366092c\",\"bundles\":[]}}",
-      "headers": {
-        "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 18:11:03 GMT",
-        "content-length": "346",
-        "content-type": "application/json; charset=utf-8",
-        "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "kj741sjulmvimer66kj7c4tgo7cce0e3"
-      },
-      "status_code": 200,
-      "type": "ok"
-    }
-  },
-  {
-    "request": {
-      "body": "{\"relays\":{\"remove\":[\"8b58d629-0908-4f6e-9dd9-82d112378fa0\"]}}",
-      "headers": {
-        "authorization": "token Po7igIilM9Gdo1hYs94+wdArFWTVExkXGQYNJObu6Gs=",
+        "authorization": "token GwWr/LQccJgaEHJeCAaxBHfPmcXowg/NeR970sHRknA=",
         "Content-Type": "application/json"
       },
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://localhost:4000/v1/relay_groups/fbdafeb8-6764-4e91-9859-3b168366092c/relays"
+      "url": "http://localhost:4000/v1/relay_groups/f6fe6343-02d9-4ca2-b27c-7beb3663bb9e/relays"
     },
     "response": {
-      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-18T18:11:02Z\",\"relays\":[],\"name\":\"myrelays\",\"inserted_at\":\"2016-04-18T18:11:02Z\",\"id\":\"fbdafeb8-6764-4e91-9859-3b168366092c\",\"bundles\":[]}}",
+      "body": "{\"relay_group\":{\"updated_at\":\"2016-04-19T18:06:58Z\",\"relays\":[],\"name\":\"myrelays\",\"inserted_at\":\"2016-04-19T18:06:58Z\",\"id\":\"f6fe6343-02d9-4ca2-b27c-7beb3663bb9e\",\"bundles\":[]}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Mon, 18 Apr 2016 18:11:03 GMT",
+        "date": "Tue, 19 Apr 2016 18:06:58 GMT",
         "content-length": "177",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "i81ohilngascdvk92b8vakdokjvsg3mi"
+        "x-request-id": "2l6n5k72crabpkar6cet8bk1dogi4a0s"
       },
       "status_code": 200,
       "type": "ok"

--- a/test/unit/cog_api/fake/relay_groups_test.exs
+++ b/test/unit/cog_api/fake/relay_groups_test.exs
@@ -173,7 +173,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
     it "removes the relay from the group" do
       relay = Client.relay_create(%{name: "relayyy", token: "1234"}, valid_endpoint) |> get_value
       group = Client.relay_group_create(%{name: "groupyy"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint)
+      group = Client.relay_group_add_relays_by_id(group.id, relay.id, valid_endpoint)
               |> List.last |> get_value
       assert group.relays != []
 

--- a/test/unit/cog_api/fake/relay_groups_test.exs
+++ b/test/unit/cog_api/fake/relay_groups_test.exs
@@ -117,7 +117,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
       relay = Client.relay_create(%{name: "relayyy", token: "1234"}, valid_endpoint) |> get_value
       group = Client.relay_group_create(%{name: "groupyy"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint)
+      group = Client.relay_group_add_relays_by_id(group.id, relay.id, valid_endpoint)
               |> List.last |> get_value
 
       [grouped_relay] = group.relays
@@ -135,7 +135,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
     it "handles a relay that was externally updated" do
       relay = Client.relay_create(%{name: "original_name", token: "1234"}, valid_endpoint) |> get_value
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint)
+      group = Client.relay_group_add_relays_by_id(group.id, relay.id, valid_endpoint)
               |> List.last |> get_value
 
       new_name = "updated_name"
@@ -152,7 +152,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
         relay = Client.relay_create(%{name: "relay1", token: "1234"}, valid_endpoint) |> get_value
         group = Client.relay_group_create(%{name: "mygroup"}, valid_endpoint) |> get_value
 
-        group = Client.relay_group_add_relays(%{name: group.name}, %{relay: relay.name}, valid_endpoint) |> get_value
+        group = Client.relay_group_add_relays_by_name(group.name, relay.name, valid_endpoint)
                 |> List.last |> get_value
 
         [grouped_relay] = group.relays
@@ -177,7 +177,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
               |> List.last |> get_value
       assert group.relays != []
 
-      group = Client.relay_group_remove_relays(group.id, relay.id, valid_endpoint)
+      group = Client.relay_group_remove_relays_by_id(group.id, relay.id, valid_endpoint)
               |> List.last |> get_value
 
       assert group.relays == []
@@ -189,14 +189,14 @@ defmodule CogApi.Fake.RelayGroupsTest do
     end
 
     context "when given the relay group name" do
-      it "reomves the relay from the group" do
+      it "removes the relay from the group" do
         relay = Client.relay_create(%{name: "relay2", token: "1234"}, valid_endpoint) |> get_value
         group = Client.relay_group_create(%{name: "my-relays"}, valid_endpoint) |> get_value
-        group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint)
+        group = Client.relay_group_add_relays_by_id(group.id, relay.id, valid_endpoint)
                 |> List.last |> get_value
         assert group.relays != []
 
-        group = Client.relay_group_remove_relays(%{name: group.name}, %{relay: relay.name}, valid_endpoint)
+        group = Client.relay_group_remove_relays_by_name(group.name, relay.name, valid_endpoint)
                 |> List.last |> get_value
 
         assert group.relays == []
@@ -214,7 +214,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
       bundle = create_bundle
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint)
+      group = Client.relay_group_add_bundles_by_id(group.id, bundle.id, valid_endpoint)
               |> List.last |> get_value
 
       [grouped_bundle] = group.bundles
@@ -235,7 +235,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_bundles(group.id, bundle_ids, valid_endpoint)
+      group = Client.relay_group_add_bundles_by_id(group.id, bundle_ids, valid_endpoint)
               |> List.last |> get_value
 
       returned_bundle_ids = MapSet.new(group.bundles, &Map.fetch!(&1, :id))
@@ -253,7 +253,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
     it "handles a bundle that was externally updated" do
       bundle = create_bundle(%{enabled: false})
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint)
+      group = Client.relay_group_add_bundles_by_id(group.id, bundle.id, valid_endpoint)
               |> List.last |> get_value
 
       Client.bundle_update(valid_endpoint, bundle.id, %{enabled: "true"})
@@ -268,7 +268,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
       it "adds the bundle to the relay group" do
         bundle = create_bundle
         group = Client.relay_group_create(%{name: "my-relays"}, valid_endpoint) |> get_value
-        group = Client.relay_group_add_bundles(%{name: group.name}, %{bundles: [bundle.name]}, valid_endpoint)
+        group = Client.relay_group_add_bundles_by_name(group.name, bundle.name, valid_endpoint)
                 |> List.last |> get_value
         [grouped_bundle] = group.bundles
 
@@ -289,7 +289,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
         group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-        group = Client.relay_group_add_bundles(%{name: group.name}, %{bundles: bundle_names}, valid_endpoint)
+        group = Client.relay_group_add_bundles_by_name(group.name, bundle_names, valid_endpoint)
                 |> List.last |> get_value
 
         returned_bundle_ids = MapSet.new(group.bundles, &Map.fetch!(&1, :id))
@@ -310,11 +310,11 @@ defmodule CogApi.Fake.RelayGroupsTest do
     it "removes the bundle from the group" do
       bundle = create_bundle
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint)
+      group = Client.relay_group_add_bundles_by_id(group.id, bundle.id, valid_endpoint)
               |> List.last |> get_value
       assert group.bundles != []
 
-      group = Client.relay_group_remove_bundles(group.id, bundle.id, valid_endpoint)
+      group = Client.relay_group_remove_bundles_by_id(group.id, bundle.id, valid_endpoint)
               |> List.last |> get_value
 
       assert group.bundles == []
@@ -331,11 +331,11 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_bundles(group.id, bundle_ids, valid_endpoint)
+      group = Client.relay_group_add_bundles_by_id(group.id, bundle_ids, valid_endpoint)
               |> List.last |> get_value
       assert group.bundles != []
 
-      group = Client.relay_group_remove_bundles(group.id, bundle_ids, valid_endpoint)
+      group = Client.relay_group_remove_bundles_by_id(group.id, bundle_ids, valid_endpoint)
               |> List.last |> get_value
       assert group.bundles == []
     end
@@ -344,11 +344,11 @@ defmodule CogApi.Fake.RelayGroupsTest do
       it "removes the bundle from the relay group" do
         bundle = create_bundle
         group = Client.relay_group_create(%{name: "my-relays"}, valid_endpoint) |> get_value
-        group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint)
+        group = Client.relay_group_add_bundles_by_id(group.id, bundle.id, valid_endpoint)
                 |> List.last |> get_value
         assert group.bundles != []
 
-        group = Client.relay_group_remove_bundles(%{name: group.name}, %{bundles: [bundle.name]}, valid_endpoint)
+        group = Client.relay_group_remove_bundles_by_name(group.name, bundle.name, valid_endpoint)
                 |> List.last |> get_value
 
         assert group.bundles == []
@@ -366,11 +366,11 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
         group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-        group = Client.relay_group_add_bundles(group.id, bundle_ids, valid_endpoint)
+        group = Client.relay_group_add_bundles_by_id(group.id, bundle_ids, valid_endpoint)
                 |> List.last |> get_value
         assert group.bundles != []
 
-        group = Client.relay_group_remove_bundles(%{name: group.name}, %{bundles: bundle_names}, valid_endpoint)
+        group = Client.relay_group_remove_bundles_by_name(group.name, bundle_names, valid_endpoint)
                 |> List.last |> get_value
         assert group.bundles == []
       end

--- a/test/unit/cog_api/fake/relay_groups_test.exs
+++ b/test/unit/cog_api/fake/relay_groups_test.exs
@@ -117,7 +117,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
       relay = Client.relay_create(%{name: "relayyy", token: "1234"}, valid_endpoint) |> get_value
       group = Client.relay_group_create(%{name: "groupyy"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_relay(group.id, relay.id, valid_endpoint) |> get_value
+      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint) |> get_value
 
       [grouped_relay] = group.relays
 
@@ -134,7 +134,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
     it "handles a relay that was externally updated" do
       relay = Client.relay_create(%{name: "original_name", token: "1234"}, valid_endpoint) |> get_value
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_relay(group.id, relay.id, valid_endpoint) |> get_value
+      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint) |> get_value
 
       new_name = "updated_name"
       Client.relay_update(relay.id, %{name: new_name}, valid_endpoint)
@@ -150,7 +150,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
         relay = Client.relay_create(%{name: "relay1", token: "1234"}, valid_endpoint) |> get_value
         group = Client.relay_group_create(%{name: "mygroup"}, valid_endpoint) |> get_value
 
-        group = Client.relay_group_add_relay(%{name: group.name}, %{relay: relay.name}, valid_endpoint) |> get_value
+        group = Client.relay_group_add_relays(%{name: group.name}, %{relay: relay.name}, valid_endpoint) |> get_value
 
         [grouped_relay] = group.relays
 
@@ -170,10 +170,10 @@ defmodule CogApi.Fake.RelayGroupsTest do
     it "removes the relay from the group" do
       relay = Client.relay_create(%{name: "relayyy", token: "1234"}, valid_endpoint) |> get_value
       group = Client.relay_group_create(%{name: "groupyy"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_relay(group.id, relay.id, valid_endpoint) |> get_value
+      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint) |> get_value
       assert group.relays != []
 
-      group = Client.relay_group_remove_relay(group.id, relay.id, valid_endpoint) |> get_value
+      group = Client.relay_group_remove_relays(group.id, relay.id, valid_endpoint) |> get_value
 
       assert group.relays == []
 
@@ -187,10 +187,10 @@ defmodule CogApi.Fake.RelayGroupsTest do
       it "reomves the relay from the group" do
         relay = Client.relay_create(%{name: "relay2", token: "1234"}, valid_endpoint) |> get_value
         group = Client.relay_group_create(%{name: "my-relays"}, valid_endpoint) |> get_value
-        group = Client.relay_group_add_relay(group.id, relay.id, valid_endpoint) |> get_value
+        group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint) |> get_value
         assert group.relays != []
 
-        group = Client.relay_group_remove_relay(%{name: group.name}, %{relay: relay.name}, valid_endpoint) |> get_value
+        group = Client.relay_group_remove_relays(%{name: group.name}, %{relay: relay.name}, valid_endpoint) |> get_value
 
         assert group.relays == []
 

--- a/test/unit/cog_api/fake/relay_groups_test.exs
+++ b/test/unit/cog_api/fake/relay_groups_test.exs
@@ -117,7 +117,8 @@ defmodule CogApi.Fake.RelayGroupsTest do
       relay = Client.relay_create(%{name: "relayyy", token: "1234"}, valid_endpoint) |> get_value
       group = Client.relay_group_create(%{name: "groupyy"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint) |> get_value
+      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint)
+              |> List.last |> get_value
 
       [grouped_relay] = group.relays
 
@@ -134,7 +135,8 @@ defmodule CogApi.Fake.RelayGroupsTest do
     it "handles a relay that was externally updated" do
       relay = Client.relay_create(%{name: "original_name", token: "1234"}, valid_endpoint) |> get_value
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint) |> get_value
+      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint)
+              |> List.last |> get_value
 
       new_name = "updated_name"
       Client.relay_update(relay.id, %{name: new_name}, valid_endpoint)
@@ -151,6 +153,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
         group = Client.relay_group_create(%{name: "mygroup"}, valid_endpoint) |> get_value
 
         group = Client.relay_group_add_relays(%{name: group.name}, %{relay: relay.name}, valid_endpoint) |> get_value
+                |> List.last |> get_value
 
         [grouped_relay] = group.relays
 
@@ -170,10 +173,12 @@ defmodule CogApi.Fake.RelayGroupsTest do
     it "removes the relay from the group" do
       relay = Client.relay_create(%{name: "relayyy", token: "1234"}, valid_endpoint) |> get_value
       group = Client.relay_group_create(%{name: "groupyy"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint) |> get_value
+      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint)
+              |> List.last |> get_value
       assert group.relays != []
 
-      group = Client.relay_group_remove_relays(group.id, relay.id, valid_endpoint) |> get_value
+      group = Client.relay_group_remove_relays(group.id, relay.id, valid_endpoint)
+              |> List.last |> get_value
 
       assert group.relays == []
 
@@ -187,10 +192,12 @@ defmodule CogApi.Fake.RelayGroupsTest do
       it "reomves the relay from the group" do
         relay = Client.relay_create(%{name: "relay2", token: "1234"}, valid_endpoint) |> get_value
         group = Client.relay_group_create(%{name: "my-relays"}, valid_endpoint) |> get_value
-        group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint) |> get_value
+        group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint)
+                |> List.last |> get_value
         assert group.relays != []
 
-        group = Client.relay_group_remove_relays(%{name: group.name}, %{relay: relay.name}, valid_endpoint) |> get_value
+        group = Client.relay_group_remove_relays(%{name: group.name}, %{relay: relay.name}, valid_endpoint)
+                |> List.last |> get_value
 
         assert group.relays == []
 
@@ -207,7 +214,8 @@ defmodule CogApi.Fake.RelayGroupsTest do
       bundle = create_bundle
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint) |> get_value
+      group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint)
+              |> List.last |> get_value
 
       [grouped_bundle] = group.bundles
 
@@ -227,7 +235,8 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_bundles(group.id, bundle_ids, valid_endpoint) |> get_value
+      group = Client.relay_group_add_bundles(group.id, bundle_ids, valid_endpoint)
+              |> List.last |> get_value
 
       returned_bundle_ids = MapSet.new(group.bundles, &Map.fetch!(&1, :id))
       intersection = MapSet.intersection(MapSet.new(bundle_ids), returned_bundle_ids)
@@ -244,7 +253,8 @@ defmodule CogApi.Fake.RelayGroupsTest do
     it "handles a bundle that was externally updated" do
       bundle = create_bundle(%{enabled: false})
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint) |> get_value
+      group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint)
+              |> List.last |> get_value
 
       Client.bundle_update(valid_endpoint, bundle.id, %{enabled: "true"})
 
@@ -258,7 +268,8 @@ defmodule CogApi.Fake.RelayGroupsTest do
       it "adds the bundle to the relay group" do
         bundle = create_bundle
         group = Client.relay_group_create(%{name: "my-relays"}, valid_endpoint) |> get_value
-        group = Client.relay_group_add_bundles(%{name: group.name}, %{bundles: [bundle.name]}, valid_endpoint) |> get_value
+        group = Client.relay_group_add_bundles(%{name: group.name}, %{bundles: [bundle.name]}, valid_endpoint)
+                |> List.last |> get_value
         [grouped_bundle] = group.bundles
 
         assert grouped_bundle.id == bundle.id
@@ -278,7 +289,8 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
         group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-        group = Client.relay_group_add_bundles(%{name: group.name}, %{bundles: bundle_names}, valid_endpoint) |> get_value
+        group = Client.relay_group_add_bundles(%{name: group.name}, %{bundles: bundle_names}, valid_endpoint)
+                |> List.last |> get_value
 
         returned_bundle_ids = MapSet.new(group.bundles, &Map.fetch!(&1, :id))
         intersection = MapSet.intersection(MapSet.new(bundle_ids), returned_bundle_ids)
@@ -298,10 +310,12 @@ defmodule CogApi.Fake.RelayGroupsTest do
     it "removes the bundle from the group" do
       bundle = create_bundle
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint) |> get_value
+      group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint)
+              |> List.last |> get_value
       assert group.bundles != []
 
-      group = Client.relay_group_remove_bundles(group.id, bundle.id, valid_endpoint) |> get_value
+      group = Client.relay_group_remove_bundles(group.id, bundle.id, valid_endpoint)
+              |> List.last |> get_value
 
       assert group.bundles == []
 
@@ -317,10 +331,12 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_bundles(group.id, bundle_ids, valid_endpoint) |> get_value
+      group = Client.relay_group_add_bundles(group.id, bundle_ids, valid_endpoint)
+              |> List.last |> get_value
       assert group.bundles != []
 
-      group = Client.relay_group_remove_bundles(group.id, bundle_ids, valid_endpoint) |> get_value
+      group = Client.relay_group_remove_bundles(group.id, bundle_ids, valid_endpoint)
+              |> List.last |> get_value
       assert group.bundles == []
     end
 
@@ -328,10 +344,12 @@ defmodule CogApi.Fake.RelayGroupsTest do
       it "removes the bundle from the relay group" do
         bundle = create_bundle
         group = Client.relay_group_create(%{name: "my-relays"}, valid_endpoint) |> get_value
-        group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint) |> get_value
+        group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint)
+                |> List.last |> get_value
         assert group.bundles != []
 
-        group = Client.relay_group_remove_bundles(%{name: group.name}, %{bundles: [bundle.name]}, valid_endpoint) |> get_value
+        group = Client.relay_group_remove_bundles(%{name: group.name}, %{bundles: [bundle.name]}, valid_endpoint)
+                |> List.last |> get_value
 
         assert group.bundles == []
 
@@ -348,10 +366,12 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
         group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-        group = Client.relay_group_add_bundles(group.id, bundle_ids, valid_endpoint) |> get_value
+        group = Client.relay_group_add_bundles(group.id, bundle_ids, valid_endpoint)
+                |> List.last |> get_value
         assert group.bundles != []
 
-        group = Client.relay_group_remove_bundles(%{name: group.name}, %{bundles: bundle_names}, valid_endpoint) |> get_value
+        group = Client.relay_group_remove_bundles(%{name: group.name}, %{bundles: bundle_names}, valid_endpoint)
+                |> List.last |> get_value
         assert group.bundles == []
       end
     end

--- a/test/unit/cog_api/fake/relays_test.exs
+++ b/test/unit/cog_api/fake/relays_test.exs
@@ -21,7 +21,7 @@ defmodule CogApi.Fake.RelaysTest do
     it "includes the group for the relay" do
       relay = Client.relay_create(%{name: "relay", token: "1234"}, valid_endpoint) |> get_value
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint)
+      group = Client.relay_group_add_relays_by_id(group.id, relay.id, valid_endpoint)
               |> List.last |> get_value
 
       last_relay = Client.relay_index(valid_endpoint) |> get_value |> List.last

--- a/test/unit/cog_api/fake/relays_test.exs
+++ b/test/unit/cog_api/fake/relays_test.exs
@@ -21,7 +21,8 @@ defmodule CogApi.Fake.RelaysTest do
     it "includes the group for the relay" do
       relay = Client.relay_create(%{name: "relay", token: "1234"}, valid_endpoint) |> get_value
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint) |> get_value
+      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint)
+              |> List.last |> get_value
 
       last_relay = Client.relay_index(valid_endpoint) |> get_value |> List.last
 

--- a/test/unit/cog_api/fake/relays_test.exs
+++ b/test/unit/cog_api/fake/relays_test.exs
@@ -21,7 +21,7 @@ defmodule CogApi.Fake.RelaysTest do
     it "includes the group for the relay" do
       relay = Client.relay_create(%{name: "relay", token: "1234"}, valid_endpoint) |> get_value
       group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
-      group = Client.relay_group_add_relay(group.id, relay.id, valid_endpoint) |> get_value
+      group = Client.relay_group_add_relays(group.id, relay.id, valid_endpoint) |> get_value
 
       last_relay = Client.relay_index(valid_endpoint) |> get_value |> List.last
 

--- a/test/unit/cog_api/http/relay_groups_test.exs
+++ b/test/unit/cog_api/http/relay_groups_test.exs
@@ -312,7 +312,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
         group = Client.relay_group_create(%{name: "groupyy"}, endpoint) |> get_value
         assert group.relays == []
 
-        group = Client.relay_group_add_relays(group.id, relay.id, endpoint) |> get_value
+        group = Client.relay_group_add_relays_by_id(group.id, relay.id, endpoint) |> get_value
 
         [grouped_relay] = group.relays
 
@@ -328,7 +328,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
           group = Client.relay_group_create(%{name: "mygroup"}, endpoint) |> get_value
           assert group.relays == []
 
-          group = Client.relay_group_add_relays(%{name: group.name}, %{relays: [relay.name]}, endpoint) |> get_value
+          group = Client.relay_group_add_relays_by_name(group.name, relay.name, endpoint) |> get_value
 
           [grouped_relay] = group.relays
 
@@ -345,7 +345,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
           group = Client.relay_group_create(%{name: "my_relays"}, endpoint) |> get_value
           assert group.relays == []
 
-          {:error, [error]} = Client.relay_group_add_relays(%{name: group.name}, %{relays: ["not here"]}, endpoint)
+          {:error, [error]} = Client.relay_group_add_relays_by_name(group.name, "not here", endpoint)
 
           assert error == "Resource not found for: 'relays'"
         end
@@ -359,10 +359,10 @@ defmodule CogApi.HTTP.RelayGroupsTest do
         endpoint = valid_endpoint
         relay = Client.relay_create(%{name: "Remove", token: "1234"}, endpoint) |> get_value
         group = Client.relay_group_create(%{name: "Remove"}, endpoint) |> get_value
-        group = Client.relay_group_add_relays(group.id, relay.id, endpoint) |> get_value
+        group = Client.relay_group_add_relays_by_id(group.id, relay.id, endpoint) |> get_value
         assert group.relays != []
 
-        group = Client.relay_group_remove_relays(group.id, relay.id, endpoint) |> get_value
+        group = Client.relay_group_remove_relays_by_id(group.id, relay.id, endpoint) |> get_value
 
         assert group.relays == []
       end
@@ -374,10 +374,10 @@ defmodule CogApi.HTTP.RelayGroupsTest do
           endpoint = valid_endpoint
           relay = Client.relay_create(%{name: "relay2", token: "1234"}, endpoint) |> get_value
           group = Client.relay_group_create(%{name: "myrelays"}, endpoint) |> get_value
-          group = Client.relay_group_add_relays(group.id, relay.id, endpoint) |> get_value
+          group = Client.relay_group_add_relays_by_id(group.id, relay.id, endpoint) |> get_value
           assert group.relays != []
 
-          group = Client.relay_group_remove_relays(%{name: group.name}, %{relays: [relay.name]}, endpoint) |> get_value
+          group = Client.relay_group_remove_relays_by_name(group.name, relay.name, endpoint) |> get_value
 
           assert group.relays == []
         end
@@ -392,7 +392,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
           group = Client.relay_group_create(%{name: "my_relay_group"}, endpoint) |> get_value
           assert group.relays == []
 
-          {:error, [error]} = Client.relay_group_remove_relays(%{name: group.name}, %{relays: ["not here"]}, endpoint)
+          {:error, [error]} = Client.relay_group_remove_relays_by_name(group.name, "not here", endpoint)
 
           assert error == "Resource not found for: 'relays'"
         end

--- a/test/unit/cog_api/http/relay_groups_test.exs
+++ b/test/unit/cog_api/http/relay_groups_test.exs
@@ -312,7 +312,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
         group = Client.relay_group_create(%{name: "groupyy"}, endpoint) |> get_value
         assert group.relays == []
 
-        group = Client.relay_group_add_relay(group.id, relay.id, endpoint) |> get_value
+        group = Client.relay_group_add_relays(group.id, relay.id, endpoint) |> get_value
 
         [grouped_relay] = group.relays
 
@@ -328,7 +328,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
           group = Client.relay_group_create(%{name: "mygroup"}, endpoint) |> get_value
           assert group.relays == []
 
-          group = Client.relay_group_add_relay(%{name: group.name}, %{relay: relay.name}, endpoint) |> get_value
+          group = Client.relay_group_add_relays(%{name: group.name}, %{relays: [relay.name]}, endpoint) |> get_value
 
           [grouped_relay] = group.relays
 
@@ -345,7 +345,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
           group = Client.relay_group_create(%{name: "my_relays"}, endpoint) |> get_value
           assert group.relays == []
 
-          {:error, [error]} = Client.relay_group_add_relay(%{name: group.name}, %{relay: "not here"}, endpoint)
+          {:error, [error]} = Client.relay_group_add_relays(%{name: group.name}, %{relays: ["not here"]}, endpoint)
 
           assert error == "Resource not found for: 'relays'"
         end
@@ -359,10 +359,10 @@ defmodule CogApi.HTTP.RelayGroupsTest do
         endpoint = valid_endpoint
         relay = Client.relay_create(%{name: "Remove", token: "1234"}, endpoint) |> get_value
         group = Client.relay_group_create(%{name: "Remove"}, endpoint) |> get_value
-        group = Client.relay_group_add_relay(group.id, relay.id, endpoint) |> get_value
+        group = Client.relay_group_add_relays(group.id, relay.id, endpoint) |> get_value
         assert group.relays != []
 
-        group = Client.relay_group_remove_relay(group.id, relay.id, endpoint) |> get_value
+        group = Client.relay_group_remove_relays(group.id, relay.id, endpoint) |> get_value
 
         assert group.relays == []
       end
@@ -374,10 +374,10 @@ defmodule CogApi.HTTP.RelayGroupsTest do
           endpoint = valid_endpoint
           relay = Client.relay_create(%{name: "relay2", token: "1234"}, endpoint) |> get_value
           group = Client.relay_group_create(%{name: "myrelays"}, endpoint) |> get_value
-          group = Client.relay_group_add_relay(group.id, relay.id, endpoint) |> get_value
+          group = Client.relay_group_add_relays(group.id, relay.id, endpoint) |> get_value
           assert group.relays != []
 
-          group = Client.relay_group_remove_relay(%{name: group.name}, %{relay: relay.name}, endpoint) |> get_value
+          group = Client.relay_group_remove_relays(%{name: group.name}, %{relays: [relay.name]}, endpoint) |> get_value
 
           assert group.relays == []
         end
@@ -392,7 +392,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
           group = Client.relay_group_create(%{name: "my_relay_group"}, endpoint) |> get_value
           assert group.relays == []
 
-          {:error, [error]} = Client.relay_group_remove_relay(%{name: group.name}, %{relay: "not here"}, endpoint)
+          {:error, [error]} = Client.relay_group_remove_relays(%{name: group.name}, %{relays: ["not here"]}, endpoint)
 
           assert error == "Resource not found for: 'relays'"
         end

--- a/test/unit/cog_api/http/relay_groups_test.exs
+++ b/test/unit/cog_api/http/relay_groups_test.exs
@@ -142,7 +142,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
         group = Client.relay_group_create(%{name: "add_bundle"}, endpoint) |> get_value
         assert group.bundles == []
 
-        group = Client.relay_group_add_bundles(group.id, bundle.id, endpoint) |> get_value
+        group = Client.relay_group_add_bundles_by_id(group.id, bundle.id, endpoint) |> get_value
 
         [grouped_bundle] = group.bundles
 
@@ -155,7 +155,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
         endpoint = valid_endpoint
         bundle = create_bundle(endpoint, "add_bundle")
 
-        {:error, [error]} = Client.relay_group_add_bundles(%{name: "foo"}, %{bundles: [bundle.name]}, endpoint)
+        {:error, [error]} = Client.relay_group_add_bundles_by_name("foo", bundle.name, endpoint)
 
         assert error == "Resource not found for: 'relay_groups'"
       end
@@ -168,7 +168,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
         group = Client.relay_group_create(%{name: "add_bundle"}, endpoint) |> get_value
         assert group.bundles == []
 
-        {:error, [error]} = Client.relay_group_add_bundles(%{name: group.name}, %{bundles: ["foo"]}, endpoint)
+        {:error, [error]} = Client.relay_group_add_bundles_by_name(group.name, "foo", endpoint)
 
         assert error == "Resource not found for: 'bundles'"
       end
@@ -184,7 +184,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
         bundle_ids = Enum.map(1..3, &create_bundle(endpoint, "add_multiple_bundles#{&1}"))
         |> Enum.map(&Map.fetch!(&1, :id))
 
-        updated_group = Client.relay_group_add_bundles(group.id, bundle_ids, endpoint) |> get_value
+        updated_group = Client.relay_group_add_bundles_by_id(group.id, bundle_ids, endpoint) |> get_value
 
         returned_bundle_ids = MapSet.new(updated_group.bundles, &Map.fetch!(&1, :id))
         intersection = MapSet.intersection(MapSet.new(bundle_ids), returned_bundle_ids)
@@ -203,7 +203,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
           group = Client.relay_group_create(%{name: "mygroup"}, endpoint) |> get_value
           assert group.bundles == []
 
-          group = Client.relay_group_add_bundles(%{name: group.name}, %{bundles: [bundle.name]}, endpoint) |> get_value
+          group = Client.relay_group_add_bundles_by_name(group.name, bundle.name, endpoint) |> get_value
 
           [grouped_bundle] = group.bundles
 
@@ -221,7 +221,7 @@ defmodule CogApi.HTTP.RelayGroupsTest do
           bundle_names = Enum.map(1..5, &create_bundle(endpoint, "add_multiple_bundles#{&1}"))
           |> Enum.map(&Map.fetch!(&1, :name))
 
-          updated_group = Client.relay_group_add_bundles(%{name: "mygroup"}, %{bundles: bundle_names}, endpoint)
+          updated_group = Client.relay_group_add_bundles_by_name("mygroup", bundle_names, endpoint)
                           |> get_value
 
           returned_bundle_names = MapSet.new(updated_group.bundles, &Map.fetch!(&1, :name))
@@ -241,10 +241,10 @@ defmodule CogApi.HTTP.RelayGroupsTest do
         endpoint = valid_endpoint
         bundle = create_bundle(endpoint, "remove_bundle")
         group = Client.relay_group_create(%{name: "add_bundle"}, endpoint) |> get_value
-        group = Client.relay_group_add_bundles(group.id, bundle.id, endpoint) |> get_value
+        group = Client.relay_group_add_bundles_by_id(group.id, bundle.id, endpoint) |> get_value
         assert group.bundles != []
 
-        group = Client.relay_group_remove_bundles(group.id, bundle.id, endpoint) |> get_value
+        group = Client.relay_group_remove_bundles_by_id(group.id, bundle.id, endpoint) |> get_value
 
         assert group.bundles == []
       end
@@ -258,10 +258,10 @@ defmodule CogApi.HTTP.RelayGroupsTest do
         |> Enum.map(&Map.fetch!(&1, :id))
 
         group = Client.relay_group_create(%{name: "mygroup"}, endpoint) |> get_value
-        group = Client.relay_group_add_bundles(group.id, bundle_ids, endpoint) |> get_value
+        group = Client.relay_group_add_bundles_by_id(group.id, bundle_ids, endpoint) |> get_value
         assert group.bundles != []
 
-        updated_group = Client.relay_group_remove_bundles(group.id, bundle_ids, endpoint) |> get_value
+        updated_group = Client.relay_group_remove_bundles_by_id(group.id, bundle_ids, endpoint) |> get_value
 
         assert updated_group.bundles == []
       end
@@ -274,11 +274,10 @@ defmodule CogApi.HTTP.RelayGroupsTest do
           name = "remove_bundle_with_name"
           bundle = create_bundle(endpoint, name)
           group = Client.relay_group_create(%{name: name}, endpoint) |> get_value
-          group = Client.relay_group_add_bundles(group.id, bundle.id, endpoint) |> get_value
+          group = Client.relay_group_add_bundles_by_id(group.id, bundle.id, endpoint) |> get_value
           assert group.bundles != []
 
-          group = Client.relay_group_remove_bundles(%{name: group.name},
-          %{bundles: [bundle.name]}, endpoint) |> get_value
+          group = Client.relay_group_remove_bundles_by_name(group.name, bundle.name, endpoint) |> get_value
 
           assert group.bundles == []
         end
@@ -293,10 +292,10 @@ defmodule CogApi.HTTP.RelayGroupsTest do
           bundle_names = Enum.map(bundles, &Map.fetch!(&1, :name))
 
           group = Client.relay_group_create(%{name: "mygroup"}, endpoint) |> get_value
-          group = Client.relay_group_add_bundles(group.id, bundle_ids, endpoint) |> get_value
+          group = Client.relay_group_add_bundles_by_id(group.id, bundle_ids, endpoint) |> get_value
           assert group.bundles != []
 
-          updated_group = Client.relay_group_remove_bundles(%{name: group.name}, %{bundles: bundle_names}, endpoint) |> get_value
+          updated_group = Client.relay_group_remove_bundles_by_name(group.name, bundle_names, endpoint) |> get_value
 
           assert updated_group.bundles == []
         end

--- a/test/unit/cog_api/http/relays_test.exs
+++ b/test/unit/cog_api/http/relays_test.exs
@@ -30,7 +30,7 @@ defmodule CogApi.HTTP.RelaysTest do
         name = "IndexGroup"
         relay = Client.relay_create(%{name: name, token: "1234"}, endpoint) |> get_value
         group = Client.relay_group_create(%{name: name}, endpoint) |> get_value
-        group = Client.relay_group_add_relay(group.id, relay.id, endpoint) |> get_value
+        group = Client.relay_group_add_relays(group.id, relay.id, endpoint) |> get_value
 
         last_relay = Client.relay_index(endpoint) |> get_value |> List.last
 

--- a/test/unit/cog_api/http/relays_test.exs
+++ b/test/unit/cog_api/http/relays_test.exs
@@ -30,7 +30,7 @@ defmodule CogApi.HTTP.RelaysTest do
         name = "IndexGroup"
         relay = Client.relay_create(%{name: name, token: "1234"}, endpoint) |> get_value
         group = Client.relay_group_create(%{name: name}, endpoint) |> get_value
-        group = Client.relay_group_add_relays(group.id, relay.id, endpoint) |> get_value
+        group = Client.relay_group_add_relays_by_id(group.id, relay.id, endpoint) |> get_value
 
         last_relay = Client.relay_index(endpoint) |> get_value |> List.last
 


### PR DESCRIPTION
Errors were not being passed correctly when there was a failure when adding a nonexistent relay to a relay group.

Fixes https://github.com/operable/cog/issues/535