### PR TITLE
Don't process errors as successful responses

### DIFF
--- a/lib/cog_api/http/api_response.ex
+++ b/lib/cog_api/http/api_response.ex
@@ -108,5 +108,4 @@ defmodule CogApi.HTTP.ApiResponse do
       :error
     end
   end
-
 end

--- a/lib/cog_api/http/api_response.ex
+++ b/lib/cog_api/http/api_response.ex
@@ -2,10 +2,12 @@ defmodule CogApi.HTTP.ApiResponse do
   alias HTTPotion.Response
 
   @no_content 204
-  @forbidden 403
-  @unprocessable 422
 
-  @error_codes [@forbidden, @unprocessable]
+  defmacrop http_error?(status_code) do
+    quote do
+      unquote(status_code) > 399
+    end
+  end
 
   def format(response, struct_map \\ nil)
 
@@ -14,7 +16,7 @@ defmodule CogApi.HTTP.ApiResponse do
   end
 
   def format(%Response{status_code: @no_content}, _), do: :ok
-  def format(response = %Response{status_code: code}, _) when code in @error_codes do
+  def format(%Response{status_code: code}=response, _) when http_error?(code) do
     format_error(response)
   end
 
@@ -106,4 +108,5 @@ defmodule CogApi.HTTP.ApiResponse do
       :error
     end
   end
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -39,6 +39,8 @@ defmodule CogApi.Mixfile do
       {:ibrowse, "~> 4.2.2", override: true},
       {:poison, "~> 2.0"},
       {:dialyxir, "~> 0.3"},
+
+      {:mix_test_watch, "~> 0.1.1", only: [:test, :dev]}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -3,8 +3,11 @@
   "exactor": {:hex, :exactor, "2.2.0"},
   "exjsx": {:hex, :exjsx, "3.2.0"},
   "exvcr": {:git, "https://github.com/operable/exvcr.git", "f64a59aeaf5e4b07bc2ba560786abb6e3bea12dc", [branch: "fix-cached-status-code"]},
+  "fs": {:hex, :fs, "0.9.2"},
   "httpotion": {:hex, :httpotion, "2.1.0"},
   "ibrowse": {:hex, :ibrowse, "4.2.2"},
   "jsx": {:hex, :jsx, "2.6.2"},
   "meck": {:hex, :meck, "0.8.4"},
-  "poison": {:hex, :poison, "2.1.0"}}
+  "mix_test_watch": {:hex, :mix_test_watch, "0.1.2"},
+  "poison": {:hex, :poison, "2.1.0"},
+  "porcelain": {:hex, :porcelain, "2.0.1"}}

--- a/test/unit/cog_api/http/api_response_test.exs
+++ b/test/unit/cog_api/http/api_response_test.exs
@@ -1,0 +1,28 @@
+defmodule CogApi.HTTP.ApiResponseTest do
+  use CogApi.HTTPCase
+
+  alias CogApi.HTTP.ApiResponse
+  alias HTTPotion.Response
+
+  describe "format" do
+    it "returns the body for a 200" do
+      http_response = %Response{status_code: 200, body: Poison.encode!(%{stuff: "things"})}
+      expected = {:ok, %{"stuff" => "things"}}
+      assert expected == ApiResponse.format(http_response)
+    end
+
+    it "returns :ok with a 204" do
+      assert :ok = ApiResponse.format(%Response{status_code: 204})
+    end
+
+    for code <- 400..500 do
+      it "returns an error for a #{code}" do
+        http_response = %Response{status_code: unquote(code), body: Poison.encode!(%{error: "oops"})}
+        expected = {:error, ["oops"]}
+        assert expected == ApiResponse.format(http_response)
+      end
+    end
+
+  end
+
+end

--- a/test/unit/cog_api/http/api_response_test.exs
+++ b/test/unit/cog_api/http/api_response_test.exs
@@ -18,11 +18,8 @@ defmodule CogApi.HTTP.ApiResponseTest do
     for code <- 400..500 do
       it "returns an error for a #{code}" do
         http_response = %Response{status_code: unquote(code), body: Poison.encode!(%{error: "oops"})}
-        expected = {:error, ["oops"]}
-        assert expected == ApiResponse.format(http_response)
+        assert {:error, ["oops"]} == ApiResponse.format(http_response)
       end
     end
-
   end
-
 end


### PR DESCRIPTION
Attempting to parse errors as successful responses has caused a few issues w/cogctl development. This PR is a quick attempt to broaden the status codes considered as error responses.