### PR TITLE
Switch up the Group/Roles

### DIFF
--- a/lib/cog_api/client.ex
+++ b/lib/cog_api/client.ex
@@ -26,6 +26,8 @@ defmodule CogApi.Client do
   @callback group_update(%Endpoint{}, String.t, %{}) :: {atom, %Group{}}
   @callback group_delete(%Endpoint{}, String.t) :: atom
   @callback group_delete(%Endpoint{}, String.t) :: {atom, [String.t]}
+  @callback group_add_role(%Endpoint{}, %Group{}, %Role{}) :: {atom, %Group{}}
+  @callback group_remove_role(%Endpoint{}, %Group{}, %Group{}) :: {atom, %Group{}}
   @callback group_add_user(%Endpoint{}, %Group{}, %User{}) :: {atom, %Group{}}
   @callback group_remove_user(%Endpoint{}, %Group{}, %User{}) :: {atom, %Group{}}
 
@@ -57,8 +59,6 @@ defmodule CogApi.Client do
   @callback role_create(%Endpoint{}, %{}) :: {atom, %Role{}}
   @callback role_update(%Endpoint{}, String.t, %{}) :: {atom, %Role{}}
   @callback role_delete(%Endpoint{}, String.t) :: atom
-  @callback role_grant(%Endpoint{}, %Role{}, %Group{}) :: {atom, %Group{}}
-  @callback role_revoke(%Endpoint{}, %Role{}, %Group{}) :: {atom, %Group{}}
   @callback role_add_permission(%Endpoint{}, %Role{}, %Permission{}) :: {atom, %Role{}}
   @callback role_remove_permission(%Endpoint{}, %Role{}, %Permission{}) :: {atom, %Role{}}
 

--- a/lib/cog_api/fake/client.ex
+++ b/lib/cog_api/fake/client.ex
@@ -61,6 +61,14 @@ defmodule CogApi.Fake.Client do
     Groups.delete(endpoint, group_id)
   end
 
+  def group_add_role(%Endpoint{}=endpoint, group, role) do
+    Groups.add_role(endpoint, group, role)
+  end
+
+  def group_remove_role(%Endpoint{}=endpoint, group, role) do
+    Groups.remove_role(endpoint, group, role)
+  end
+
   def group_add_user(%Endpoint{}=endpoint, group, user) do
     Groups.add_user(endpoint, group, user)
   end
@@ -151,14 +159,6 @@ defmodule CogApi.Fake.Client do
 
   def role_delete(%Endpoint{}=endpoint, role_id) do
     Roles.delete(endpoint, role_id)
-  end
-
-  def role_grant(%Endpoint{}=endpoint, role, group) do
-    Roles.grant(endpoint, role, group)
-  end
-
-  def role_revoke(%Endpoint{}=endpoint, role, group) do
-    Roles.revoke(endpoint, role, group)
   end
 
   def role_add_permission(endpoint, role, permission) do

--- a/lib/cog_api/fake/groups.ex
+++ b/lib/cog_api/fake/groups.ex
@@ -5,6 +5,7 @@ defmodule CogApi.Fake.Groups do
   alias CogApi.Endpoint
   alias CogApi.Fake.Server
   alias CogApi.Resources.Group
+  alias CogApi.Resources.Role
   alias CogApi.Resources.User
 
   def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
@@ -49,6 +50,22 @@ defmodule CogApi.Fake.Groups do
     else
       {:error, ["The group could not be deleted"]}
     end
+  end
+
+  def add_role(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
+  def add_role(%Endpoint{}, %Group{id: group_id}, %Role{name: role_name}) do
+    group = Server.show(Group, group_id)
+    role = Server.show_by_key(Role, :name, role_name)
+    group = %{group | roles: group.roles ++ [role]}
+    {:ok, Server.update(Group, group.id, group)}
+  end
+
+  def remove_role(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
+  def remove_role(%Endpoint{}, %Group{id: group_id}, %Role{name: role_name}) do
+    group = Server.show(Group, group_id)
+    role = Server.show_by_key(Role, :name, role_name)
+    group = %{group | roles: List.delete(group.roles, role)}
+    {:ok, Server.update(Group, group.id, group)}
   end
 
   def add_user(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint

--- a/lib/cog_api/fake/roles.ex
+++ b/lib/cog_api/fake/roles.ex
@@ -37,20 +37,6 @@ defmodule CogApi.Fake.Roles do
     :ok
   end
 
-  def grant(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
-  def grant(%Endpoint{}, role, %Group{id: group_id}) do
-    group = Server.show(Group, group_id)
-    group = %{group | roles: group.roles ++ [role]}
-    {:ok, Server.update(Group, group.id, group)}
-  end
-
-  def revoke(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
-  def revoke(%Endpoint{}, role, %Group{id: group_id}) do
-    group = Server.show(Group, group_id)
-    group = %{group | roles: List.delete(group.roles, role)}
-    {:ok, Server.update(Group, group.id, group)}
-  end
-
   def add_permission(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def add_permission(%Endpoint{}, role, permission) do
     if found_permission  = matching_permission(Server.index(Permission), permission) do

--- a/lib/cog_api/fake/roles.ex
+++ b/lib/cog_api/fake/roles.ex
@@ -38,13 +38,15 @@ defmodule CogApi.Fake.Roles do
   end
 
   def grant(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
-  def grant(%Endpoint{}, role, group) do
+  def grant(%Endpoint{}, role, %Group{id: group_id}) do
+    group = Server.show(Group, group_id)
     group = %{group | roles: group.roles ++ [role]}
     {:ok, Server.update(Group, group.id, group)}
   end
 
   def revoke(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
-  def revoke(%Endpoint{}, role, group) do
+  def revoke(%Endpoint{}, role, %Group{id: group_id}) do
+    group = Server.show(Group, group_id)
     group = %{group | roles: List.delete(group.roles, role)}
     {:ok, Server.update(Group, group.id, group)}
   end

--- a/lib/cog_api/http/client.ex
+++ b/lib/cog_api/http/client.ex
@@ -61,6 +61,14 @@ defmodule CogApi.HTTP.Client do
     Groups.delete(endpoint, group_id)
   end
 
+  def group_add_role(%Endpoint{}=endpoint, group, role) do
+    Groups.add_role(endpoint, group, role)
+  end
+
+  def group_remove_role(%Endpoint{}=endpoint, group, role) do
+    Groups.remove_role(endpoint, group, role)
+  end
+
   def group_add_user(%Endpoint{}=endpoint, group, user) do
     Groups.add_user(endpoint, group, user)
   end
@@ -151,14 +159,6 @@ defmodule CogApi.HTTP.Client do
 
   def role_delete(%Endpoint{}=endpoint, role_id) do
     Roles.delete(endpoint, role_id)
-  end
-
-  def role_grant(%Endpoint{}=endpoint, role, group) do
-    Roles.grant(endpoint, role, group)
-  end
-
-  def role_revoke(%Endpoint{}=endpoint, role, group) do
-    Roles.revoke(endpoint, role, group)
   end
 
   def role_add_permission(endpoint, role, permission) do

--- a/lib/cog_api/http/roles.ex
+++ b/lib/cog_api/http/roles.ex
@@ -34,28 +34,6 @@ defmodule CogApi.HTTP.Roles do
     |> ApiResponse.format(%{"role" => Role.format})
   end
 
-  def grant(%Endpoint{}=endpoint, role, group) do
-    update_roles_for_group(endpoint, role, group, :grant)
-  end
-
-  def revoke(%Endpoint{}=endpoint, role, group) do
-    update_roles_for_group(endpoint, role, group, :revoke)
-  end
-
-  def update_roles_for_group(endpoint, role, group, action) do
-    path = "groups/#{group.id}/roles"
-    Base.post(endpoint, path, %{roles: %{action => [role.name]}})
-    |> format_response(group)
-  end
-
-  defp format_response(response, group) do
-    roles = ApiResponse.parse_struct(response,  %{"roles" => [Role.format]})
-    {
-      ApiResponse.type(response),
-      %{group | roles: roles }
-    }
-  end
-
   def add_permission(endpoint, role, permission) do
     build_role_with_new_permissions(endpoint, role, permission, :grant)
   end

--- a/test/fixtures/vcr/group_add_role.json
+++ b/test/fixtures/vcr/group_add_role.json
@@ -11,14 +11,14 @@
       "url": "http://localhost:4000/v1/token"
     },
     "response": {
-      "body": "{\"token\":{\"value\":\"bQqHTr2hKnzUumjpA3qb3cGDQUZeEYHDOQBIH6+f7Cc=\"}}",
+      "body": "{\"token\":{\"value\":\"JEAaHmZyVv4tgk4Tr9CL49YyMxlq14YeH6DOUF9DCkc=\"}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Thu, 31 Mar 2016 19:52:07 GMT",
+        "date": "Mon, 18 Apr 2016 14:03:30 GMT",
         "content-length": "66",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "e10btaa03dr0simp0ejpdm4b6qa6od5g"
+        "x-request-id": "subhc8k6ig29apbrk8kmrbugtn3a0d1n"
       },
       "status_code": 201,
       "type": "ok"
@@ -28,7 +28,7 @@
     "request": {
       "body": "{\"role\":{\"name\":\"role_grant\"}}",
       "headers": {
-        "authorization": "token bQqHTr2hKnzUumjpA3qb3cGDQUZeEYHDOQBIH6+f7Cc=",
+        "authorization": "token JEAaHmZyVv4tgk4Tr9CL49YyMxlq14YeH6DOUF9DCkc=",
         "Content-Type": "application/json"
       },
       "method": "post",
@@ -37,15 +37,15 @@
       "url": "http://localhost:4000/v1/roles"
     },
     "response": {
-      "body": "{\"role\":{\"permissions\":[],\"name\":\"role_grant\",\"id\":\"7d012052-3fe7-49dc-aab7-05b6717d8454\"}}",
+      "body": "{\"role\":{\"permissions\":[],\"name\":\"role_grant\",\"id\":\"6512ad61-45d8-49ae-897f-4908cfbd41d1\",\"groups\":[]}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Thu, 31 Mar 2016 19:52:08 GMT",
-        "content-length": "91",
+        "date": "Mon, 18 Apr 2016 14:03:31 GMT",
+        "content-length": "103",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "mn1ocnsbvuk2hknnkkm9ldsfjc41prhg",
-        "location": "/v1/roles/7d012052-3fe7-49dc-aab7-05b6717d8454"
+        "x-request-id": "jfqovgr4uudl1n9ooc94qeugv5m2vj1h",
+        "location": "/v1/roles/6512ad61-45d8-49ae-897f-4908cfbd41d1"
       },
       "status_code": 201,
       "type": "ok"
@@ -55,7 +55,7 @@
     "request": {
       "body": "{\"group\":{\"name\":\"group_role_grant\"}}",
       "headers": {
-        "authorization": "token bQqHTr2hKnzUumjpA3qb3cGDQUZeEYHDOQBIH6+f7Cc=",
+        "authorization": "token JEAaHmZyVv4tgk4Tr9CL49YyMxlq14YeH6DOUF9DCkc=",
         "Content-Type": "application/json"
       },
       "method": "post",
@@ -64,15 +64,15 @@
       "url": "http://localhost:4000/v1/groups"
     },
     "response": {
-      "body": "{\"group\":{\"name\":\"group_role_grant\",\"members\":{\"users\":[],\"roles\":[],\"groups\":[]},\"id\":\"58508684-0272-4097-af9d-2951c263d988\"}}",
+      "body": "{\"group\":{\"name\":\"group_role_grant\",\"members\":{\"users\":[],\"roles\":[],\"groups\":[]},\"id\":\"da2fd535-3eb2-4055-bc7c-b6eb235962fd\"}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Thu, 31 Mar 2016 19:52:08 GMT",
+        "date": "Mon, 18 Apr 2016 14:03:31 GMT",
         "content-length": "127",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "khvasmva9mni8ompdigig18amkgv9645",
-        "location": "/v1/groups/58508684-0272-4097-af9d-2951c263d988"
+        "x-request-id": "3v31cv28f919jsdroiglmf7rqcbjf91n",
+        "location": "/v1/groups/da2fd535-3eb2-4055-bc7c-b6eb235962fd"
       },
       "status_code": 201,
       "type": "ok"
@@ -82,23 +82,23 @@
     "request": {
       "body": "{\"roles\":{\"grant\":[\"role_grant\"]}}",
       "headers": {
-        "authorization": "token bQqHTr2hKnzUumjpA3qb3cGDQUZeEYHDOQBIH6+f7Cc=",
+        "authorization": "token JEAaHmZyVv4tgk4Tr9CL49YyMxlq14YeH6DOUF9DCkc=",
         "Content-Type": "application/json"
       },
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://localhost:4000/v1/groups/58508684-0272-4097-af9d-2951c263d988/roles"
+      "url": "http://localhost:4000/v1/groups/da2fd535-3eb2-4055-bc7c-b6eb235962fd/roles"
     },
     "response": {
-      "body": "{\"roles\":[{\"permissions\":[],\"name\":\"role_grant\",\"id\":\"7d012052-3fe7-49dc-aab7-05b6717d8454\"}]}",
+      "body": "{\"roles\":[{\"permissions\":[],\"name\":\"role_grant\",\"id\":\"6512ad61-45d8-49ae-897f-4908cfbd41d1\"}]}",
       "headers": {
         "server": "Cowboy",
-        "date": "Thu, 31 Mar 2016 19:52:08 GMT",
+        "date": "Mon, 18 Apr 2016 14:03:31 GMT",
         "content-length": "94",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "imujms165i54qq6npsqnn7jc3eg6khds"
+        "x-request-id": "he2i52eeo4ii4d0hnqkmjd43dt26i6ek"
       },
       "status_code": 200,
       "type": "ok"

--- a/test/fixtures/vcr/group_remove_role.json
+++ b/test/fixtures/vcr/group_remove_role.json
@@ -11,14 +11,14 @@
       "url": "http://localhost:4000/v1/token"
     },
     "response": {
-      "body": "{\"token\":{\"value\":\"iBi/8MlO2F9UQcMiJHJyvXcnUWK0xJhs+sj7amlKv6M=\"}}",
+      "body": "{\"token\":{\"value\":\"DfxLaqJmldzKgCwde+Fp3/q1jcPclAsjdud/RFWPBH8=\"}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Thu, 31 Mar 2016 19:52:16 GMT",
+        "date": "Mon, 18 Apr 2016 14:04:04 GMT",
         "content-length": "66",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "59lg3o60576m1si8bfbvmvlb60fda0vb"
+        "x-request-id": "viridhbtck6lr87lmimncor56bnjn6eq"
       },
       "status_code": 201,
       "type": "ok"
@@ -28,7 +28,7 @@
     "request": {
       "body": "{\"role\":{\"name\":\"role_revoke\"}}",
       "headers": {
-        "authorization": "token iBi/8MlO2F9UQcMiJHJyvXcnUWK0xJhs+sj7amlKv6M=",
+        "authorization": "token DfxLaqJmldzKgCwde+Fp3/q1jcPclAsjdud/RFWPBH8=",
         "Content-Type": "application/json"
       },
       "method": "post",
@@ -37,15 +37,15 @@
       "url": "http://localhost:4000/v1/roles"
     },
     "response": {
-      "body": "{\"role\":{\"permissions\":[],\"name\":\"role_revoke\",\"id\":\"c956ec12-4ee8-4faa-add4-5e11020cbf9b\"}}",
+      "body": "{\"role\":{\"permissions\":[],\"name\":\"role_revoke\",\"id\":\"22e2912f-b473-49ff-b2cb-c48a2c905e01\",\"groups\":[]}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Thu, 31 Mar 2016 19:52:16 GMT",
-        "content-length": "92",
+        "date": "Mon, 18 Apr 2016 14:04:04 GMT",
+        "content-length": "104",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "gkfmr3mr57du5rrel7q1lt18k6hc9f6f",
-        "location": "/v1/roles/c956ec12-4ee8-4faa-add4-5e11020cbf9b"
+        "x-request-id": "8cs1ul4aleom17un6e2mje3hd464qta6",
+        "location": "/v1/roles/22e2912f-b473-49ff-b2cb-c48a2c905e01"
       },
       "status_code": 201,
       "type": "ok"
@@ -55,7 +55,7 @@
     "request": {
       "body": "{\"group\":{\"name\":\"group_role_revoke\"}}",
       "headers": {
-        "authorization": "token iBi/8MlO2F9UQcMiJHJyvXcnUWK0xJhs+sj7amlKv6M=",
+        "authorization": "token DfxLaqJmldzKgCwde+Fp3/q1jcPclAsjdud/RFWPBH8=",
         "Content-Type": "application/json"
       },
       "method": "post",
@@ -64,15 +64,15 @@
       "url": "http://localhost:4000/v1/groups"
     },
     "response": {
-      "body": "{\"group\":{\"name\":\"group_role_revoke\",\"members\":{\"users\":[],\"roles\":[],\"groups\":[]},\"id\":\"3bcb4280-7aa0-4224-a17a-bd60980be77d\"}}",
+      "body": "{\"group\":{\"name\":\"group_role_revoke\",\"members\":{\"users\":[],\"roles\":[],\"groups\":[]},\"id\":\"f282cd87-5660-40fa-8bba-bc3d514d1fa9\"}}",
       "headers": {
         "server": "Cowboy",
-        "date": "Thu, 31 Mar 2016 19:52:16 GMT",
+        "date": "Mon, 18 Apr 2016 14:04:04 GMT",
         "content-length": "128",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "97nmgrl4kt9e0e9fh3kcslt83r2oag76",
-        "location": "/v1/groups/3bcb4280-7aa0-4224-a17a-bd60980be77d"
+        "x-request-id": "h3vfkgl6ckr5ctjjkui205vhm0402f4t",
+        "location": "/v1/groups/f282cd87-5660-40fa-8bba-bc3d514d1fa9"
       },
       "status_code": 201,
       "type": "ok"
@@ -82,23 +82,23 @@
     "request": {
       "body": "{\"roles\":{\"grant\":[\"role_revoke\"]}}",
       "headers": {
-        "authorization": "token iBi/8MlO2F9UQcMiJHJyvXcnUWK0xJhs+sj7amlKv6M=",
+        "authorization": "token DfxLaqJmldzKgCwde+Fp3/q1jcPclAsjdud/RFWPBH8=",
         "Content-Type": "application/json"
       },
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://localhost:4000/v1/groups/3bcb4280-7aa0-4224-a17a-bd60980be77d/roles"
+      "url": "http://localhost:4000/v1/groups/f282cd87-5660-40fa-8bba-bc3d514d1fa9/roles"
     },
     "response": {
-      "body": "{\"roles\":[{\"permissions\":[],\"name\":\"role_revoke\",\"id\":\"c956ec12-4ee8-4faa-add4-5e11020cbf9b\"}]}",
+      "body": "{\"roles\":[{\"permissions\":[],\"name\":\"role_revoke\",\"id\":\"22e2912f-b473-49ff-b2cb-c48a2c905e01\"}]}",
       "headers": {
         "server": "Cowboy",
-        "date": "Thu, 31 Mar 2016 19:52:17 GMT",
+        "date": "Mon, 18 Apr 2016 14:04:04 GMT",
         "content-length": "95",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "53n715m9652iaeikf7b21kge839l47jq"
+        "x-request-id": "ev1elaum0k6gd9s6ln9qe71cba50bmqr"
       },
       "status_code": 200,
       "type": "ok"
@@ -108,23 +108,23 @@
     "request": {
       "body": "{\"roles\":{\"revoke\":[\"role_revoke\"]}}",
       "headers": {
-        "authorization": "token iBi/8MlO2F9UQcMiJHJyvXcnUWK0xJhs+sj7amlKv6M=",
+        "authorization": "token DfxLaqJmldzKgCwde+Fp3/q1jcPclAsjdud/RFWPBH8=",
         "Content-Type": "application/json"
       },
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "http://localhost:4000/v1/groups/3bcb4280-7aa0-4224-a17a-bd60980be77d/roles"
+      "url": "http://localhost:4000/v1/groups/f282cd87-5660-40fa-8bba-bc3d514d1fa9/roles"
     },
     "response": {
       "body": "{\"roles\":[]}",
       "headers": {
         "server": "Cowboy",
-        "date": "Thu, 31 Mar 2016 19:52:17 GMT",
+        "date": "Mon, 18 Apr 2016 14:04:04 GMT",
         "content-length": "12",
         "content-type": "application/json; charset=utf-8",
         "cache-control": "max-age=0, private, must-revalidate",
-        "x-request-id": "0h45tj4eknggsouslbo8b2tujtgjm7ja"
+        "x-request-id": "9c65cds8ngg4kne5qtrhlbbd0cr7s9dr"
       },
       "status_code": 200,
       "type": "ok"

--- a/test/unit/cog_api/fake/groups_test.exs
+++ b/test/unit/cog_api/fake/groups_test.exs
@@ -2,6 +2,7 @@ defmodule CogApi.Fake.GroupsTest do
   use CogApi.FakeCase
 
   alias CogApi.Fake.Client
+  alias CogApi.Resources.Group
 
   doctest CogApi.Fake.Groups
 
@@ -83,6 +84,33 @@ defmodule CogApi.Fake.GroupsTest do
     end
   end
 
+  describe "group_add_role" do
+    it "returns the roles that are associated with that group" do
+      role = Client.role_create(fake_endpoint, %{name: "role"}) |> get_value
+      group = Client.group_create(fake_endpoint, %{name: "group"}) |> get_value
+
+      updated_group = Client.group_add_role(fake_endpoint, %Group{id: group.id}, role) |> get_value
+
+      first_role = List.first updated_group.roles
+      assert updated_group.name == group.name
+      assert first_role.id == role.id
+    end
+  end
+
+  describe "group_remove_role" do
+    it "returns the roles that are associated with that group" do
+      role = Client.role_create(fake_endpoint, %{name: "role123"}) |> get_value
+      group = Client.group_create(fake_endpoint, %{name: "group123"}) |> get_value
+      group = Client.group_add_role(fake_endpoint, group, role) |> get_value
+      assert group.roles != []
+
+      updated_group = Client.group_remove_role(fake_endpoint, %Group{id: group.id}, role) |> get_value
+
+      assert updated_group.name == group.name
+      assert updated_group.roles == []
+    end
+  end
+
   describe "group_add_user" do
     it "adds the user to the group" do
       group = Client.group_create(fake_endpoint, %{name: "user_group"}) |> get_value
@@ -94,7 +122,6 @@ defmodule CogApi.Fake.GroupsTest do
       {:ok, group} = Client.group_add_user(fake_endpoint, group, second_user)
 
       assert ids_for(group.users) == [first_user.id, second_user.id]
-
 
       first_user = Client.user_show(fake_endpoint, first_user.id) |> get_value
       assert ids_for(first_user.groups) == [group.id]

--- a/test/unit/cog_api/fake/roles_test.exs
+++ b/test/unit/cog_api/fake/roles_test.exs
@@ -2,7 +2,6 @@ defmodule CogApi.Fake.RolesTest do
   use CogApi.FakeCase
 
   alias CogApi.Fake.Client
-  alias CogApi.Resources.Group
   alias CogApi.Resources.Permission
 
   doctest CogApi.Fake.Roles
@@ -41,7 +40,7 @@ defmodule CogApi.Fake.RolesTest do
         role = Client.role_create(fake_endpoint, %{name: "role"}) |> get_value
         group = Client.group_create(fake_endpoint, %{name: "group"}) |> get_value
 
-        group = Client.role_grant(fake_endpoint, role, group) |> get_value
+        group = Client.group_add_role(fake_endpoint, group, role) |> get_value
 
         role = Client.role_show(fake_endpoint, role.id) |> get_value
 
@@ -111,33 +110,6 @@ defmodule CogApi.Fake.RolesTest do
     it "returns :ok" do
       {:ok, role} = Client.role_create(fake_endpoint, %{name: "new role"})
       assert :ok == Client.role_delete(fake_endpoint, role.id)
-    end
-  end
-
-  describe "role_grant" do
-    it "returns the roles that are associated with that group" do
-      role = Client.role_create(fake_endpoint, %{name: "role"}) |> get_value
-      group = Client.group_create(fake_endpoint, %{name: "group"}) |> get_value
-
-      updated_group = Client.role_grant(fake_endpoint, role, %Group{id: group.id}) |> get_value
-
-      first_role = List.first updated_group.roles
-      assert updated_group.name == group.name
-      assert first_role.id == role.id
-    end
-  end
-
-  describe "role_revoke" do
-    it "returns the roles that are associated with that group" do
-      role = Client.role_create(fake_endpoint, %{name: "role123"}) |> get_value
-      group = Client.group_create(fake_endpoint, %{name: "group123"}) |> get_value
-      group = Client.role_grant(fake_endpoint, role, group) |> get_value
-      assert group.roles != []
-
-      updated_group = Client.role_revoke(fake_endpoint, role, %Group{id: group.id}) |> get_value
-
-      assert updated_group.name == group.name
-      assert updated_group.roles == []
     end
   end
 

--- a/test/unit/cog_api/fake/roles_test.exs
+++ b/test/unit/cog_api/fake/roles_test.exs
@@ -2,6 +2,7 @@ defmodule CogApi.Fake.RolesTest do
   use CogApi.FakeCase
 
   alias CogApi.Fake.Client
+  alias CogApi.Resources.Group
   alias CogApi.Resources.Permission
 
   doctest CogApi.Fake.Roles
@@ -118,9 +119,10 @@ defmodule CogApi.Fake.RolesTest do
       role = Client.role_create(fake_endpoint, %{name: "role"}) |> get_value
       group = Client.group_create(fake_endpoint, %{name: "group"}) |> get_value
 
-      updated_group = Client.role_grant(fake_endpoint, role, group) |> get_value
+      updated_group = Client.role_grant(fake_endpoint, role, %Group{id: group.id}) |> get_value
 
       first_role = List.first updated_group.roles
+      assert updated_group.name == group.name
       assert first_role.id == role.id
     end
   end
@@ -132,9 +134,10 @@ defmodule CogApi.Fake.RolesTest do
       group = Client.role_grant(fake_endpoint, role, group) |> get_value
       assert group.roles != []
 
-      group = Client.role_revoke(fake_endpoint, role, group) |> get_value
+      updated_group = Client.role_revoke(fake_endpoint, role, %Group{id: group.id}) |> get_value
 
-      assert group.roles == []
+      assert updated_group.name == group.name
+      assert updated_group.roles == []
     end
   end
 

--- a/test/unit/cog_api/fake/users_test.exs
+++ b/test/unit/cog_api/fake/users_test.exs
@@ -39,7 +39,7 @@ defmodule CogApi.Fake.UsersTest do
       created_user = Client.user_create(fake_endpoint, params) |> get_value
       role = Client.role_create(fake_endpoint, %{name: "user_show_role"}) |> get_value
       group = Client.group_create(fake_endpoint, %{name: "user_show_group"}) |> get_value
-      Client.role_grant(fake_endpoint, role, group)
+      Client.group_add_role(fake_endpoint, group, role)
       Client.group_add_user(fake_endpoint, group, created_user)
 
       found_user = Client.user_show(fake_endpoint, created_user.id) |> get_value

--- a/test/unit/cog_api/http/groups_test.exs
+++ b/test/unit/cog_api/http/groups_test.exs
@@ -114,6 +114,37 @@ defmodule CogApi.HTTP.GroupsTest do
     end
   end
 
+  describe "group_add_role" do
+    it "returns the roles that are associated with that group" do
+      cassette "group_add_role" do
+        endpoint = valid_endpoint
+        role = Client.role_create(endpoint, %{name: "role_grant"}) |> get_value
+        group = Client.group_create(endpoint, %{name: "group_role_grant"}) |> get_value
+
+        updated_group = Client.group_add_role(endpoint, group, role) |> get_value
+
+        first_role = List.first updated_group.roles
+        assert first_role.id == role.id
+      end
+    end
+  end
+
+  describe "group_remove_role" do
+    it "returns the roles that are associated with that group" do
+      cassette "group_remove_role" do
+        endpoint = valid_endpoint
+        role = Client.role_create(endpoint, %{name: "role_revoke"}) |> get_value
+        group = Client.group_create(endpoint, %{name: "group_role_revoke"}) |> get_value
+        group = Client.group_add_role(endpoint, group, role) |> get_value
+        assert group.roles != []
+
+        group = Client.group_remove_role(endpoint, group, role) |> get_value
+
+        assert group.roles == []
+      end
+    end
+  end
+
   describe "group_add_user" do
     it "adds the user to the group" do
       cassette "groups_add" do
@@ -153,7 +184,7 @@ defmodule CogApi.HTTP.GroupsTest do
   defp create_group_with_user_and_role(endpoint, test_name) do
     {group, user} = create_group_with_user(endpoint, test_name)
     role = Client.role_create(endpoint, %{name: "group#{test_name}"}) |> get_value
-    group = Client.role_grant(endpoint, role, group) |> get_value
+    group = Client.group_add_role(endpoint, group, role) |> get_value
 
     {group, user, role}
   end

--- a/test/unit/cog_api/http/roles_test.exs
+++ b/test/unit/cog_api/http/roles_test.exs
@@ -93,37 +93,6 @@ defmodule CogApi.HTTP.RolesTest do
     end
   end
 
-  describe "role_grant" do
-    it "returns the roles that are associated with that group" do
-      cassette "role_grant" do
-        endpoint = valid_endpoint
-        role = Client.role_create(endpoint, %{name: "role_grant"}) |> get_value
-        group = Client.group_create(endpoint, %{name: "group_role_grant"}) |> get_value
-
-        updated_group = Client.role_grant(endpoint, role, group) |> get_value
-
-        first_role = List.first updated_group.roles
-        assert first_role.id == role.id
-      end
-    end
-  end
-
-  describe "role_revoke" do
-    it "returns the roles that are associated with that group" do
-      cassette "role_revoke" do
-        endpoint = valid_endpoint
-        role = Client.role_create(endpoint, %{name: "role_revoke"}) |> get_value
-        group = Client.group_create(endpoint, %{name: "group_role_revoke"}) |> get_value
-        group = Client.role_grant(endpoint, role, group) |> get_value
-        assert group.roles != []
-
-        group = Client.role_revoke(endpoint, role, group) |> get_value
-
-        assert group.roles == []
-      end
-    end
-  end
-
   describe "role_add_permission" do
     it "adds the permission to the role" do
       cassette "role_add_permission" do

--- a/test/unit/cog_api/http/users_test.exs
+++ b/test/unit/cog_api/http/users_test.exs
@@ -33,7 +33,7 @@ defmodule CogApi.HTTP.UsersTest do
           created_user = Client.user_create(endpoint, params) |> get_value
           role = Client.role_create(endpoint, %{name: "user_show_role"}) |> get_value
           group = Client.group_create(endpoint, %{name: "user_show_group"}) |> get_value
-          Client.role_grant(endpoint, role, group)
+          Client.group_add_role(endpoint, group, role)
           Client.group_add_user(endpoint, group, created_user)
 
           found_user = Client.user_show(endpoint, created_user.id) |> get_value


### PR DESCRIPTION
* Fix an issue with the fake. We should look up the role and group by their keys instead of using what was passed in. This is what the API does and we should mirror that.
* Rename the `Role.grant` `Role.revoke` to instead be `Group.add_role` and `Group.remove_role`. This keeps the pattern of returning whatever the "main" model is being passed through. This also remove the use of `grant/revoke` since we use `add/remove` everywhere else.