### PR TITLE
Fake Improvements

### DIFF
--- a/lib/cog_api/fake/authentication.ex
+++ b/lib/cog_api/fake/authentication.ex
@@ -7,7 +7,7 @@ defmodule CogApi.Fake.Authentication do
     if password != "INVALID_PASSWORD" && user_exists?(username) do
       {:ok, %{endpoint | token: "1234"}}
     else
-      {:error, ["Invalid username/password"]}
+      CogApi.Fake.Helpers.return_error("Invalid username/password")
     end
   end
 

--- a/lib/cog_api/fake/bundles.ex
+++ b/lib/cog_api/fake/bundles.ex
@@ -44,7 +44,7 @@ defmodule CogApi.Fake.Bundles do
         new_bundle = Server.create(Bundle, new_bundle)
         show(endpoint, new_bundle.id)
       else
-        {:error, ["Invalid bundle config"]}
+        return_error("Invalid bundle config")
       end
     end
   end
@@ -66,7 +66,7 @@ defmodule CogApi.Fake.Bundles do
   end
 
   def update(%Endpoint{token: _}, _, %{}) do
-    {:error, "You can only enable or disable a bundle"}
+    return_error("You can only enable or disable a bundle")
   end
 
   def delete(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint

--- a/lib/cog_api/fake/bundles.ex
+++ b/lib/cog_api/fake/bundles.ex
@@ -70,14 +70,7 @@ defmodule CogApi.Fake.Bundles do
   end
 
   def delete(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
-  def delete(%Endpoint{token: _}, id) do
-    if Server.show(Bundle, id) do
-      Server.delete(Bundle, id)
-      :ok
-    else
-      {:error, ["The bundle could not be deleted"]}
-    end
-  end
+  def delete(%Endpoint{token: _}, id), do: Server.delete(Bundle, id)
 
   defp ensure_bundle_encode_status(status) do
     Bundle.encode_status(status)

--- a/lib/cog_api/fake/chat_handles.ex
+++ b/lib/cog_api/fake/chat_handles.ex
@@ -16,10 +16,7 @@ defmodule CogApi.Fake.ChatHandles do
   end
 
   def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
-  def delete(%Endpoint{token: _}, id) do
-    Server.delete(ChatHandle, id)
-    :ok
-  end
+  def delete(%Endpoint{token: _}, id), do: Server.delete(ChatHandle, id)
 
   def for_user(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def for_user(id, %Endpoint{token: _}) do

--- a/lib/cog_api/fake/groups.ex
+++ b/lib/cog_api/fake/groups.ex
@@ -45,14 +45,7 @@ defmodule CogApi.Fake.Groups do
   end
 
   def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
-  def delete(%Endpoint{token: _}, id) do
-    if Server.show(Group, id) do
-      Server.delete(Group, id)
-      :ok
-    else
-      {:error, ["The group could not be deleted"]}
-    end
-  end
+  def delete(%Endpoint{token: _}, id), do: Server.delete(Group, id)
 
   def add_role(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def add_role(%Endpoint{}, %Group{id: group_id}, %Role{name: role_name}) do

--- a/lib/cog_api/fake/helpers.ex
+++ b/lib/cog_api/fake/helpers.ex
@@ -1,4 +1,8 @@
 defmodule CogApi.Fake.Helpers do
+  def return_error(error) do
+    {:error, [error]}
+  end
+
   def catch_errors(struct, params, fun) do
     keys_to_verify = Map.keys struct
 

--- a/lib/cog_api/fake/permissions.ex
+++ b/lib/cog_api/fake/permissions.ex
@@ -40,10 +40,6 @@ defmodule CogApi.Fake.Permissions do
     end
   end
 
-  defp return_error(error) do
-    {:error, [error]}
-  end
-
   defp build_namespaced_name(name) do
     case String.split(name, ":") do
       [namespace, name] -> [namespace, name]

--- a/lib/cog_api/fake/relay_groups.ex
+++ b/lib/cog_api/fake/relay_groups.ex
@@ -50,7 +50,7 @@ defmodule CogApi.Fake.RelayGroups do
   defp delete_relay_group(%RelayGroup{}=group) do
     Server.delete(RelayGroup, group.id)
   end
-  defp delete_relay_group(_), do: {:error, ["The relay group could not be deleted"]}
+  defp delete_relay_group(_), do: return_error("The relay group could not be deleted")
 
   def add_relay(_, _, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def add_relay(%{name: name}, %{relay: relay_name}, %Endpoint{token: _}) do

--- a/lib/cog_api/fake/relays.ex
+++ b/lib/cog_api/fake/relays.ex
@@ -45,12 +45,5 @@ defmodule CogApi.Fake.Relays do
     relay = Server.show_by_key(Relay, :name, name)
     delete(relay.id, endpoint)
   end
-  def delete(id, %Endpoint{token: _}) do
-    if Server.show(Relay, id) do
-      Server.delete(Relay, id)
-      :ok
-    else
-      {:error, ["The relay could not be deleted"]}
-    end
-  end
+  def delete(id, %Endpoint{token: _}), do: Server.delete(Relay, id)
 end

--- a/lib/cog_api/fake/roles.ex
+++ b/lib/cog_api/fake/roles.ex
@@ -37,10 +37,7 @@ defmodule CogApi.Fake.Roles do
   end
 
   def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
-  def delete(%Endpoint{token: _}, id) do
-    Server.delete(Role, id)
-    :ok
-  end
+  def delete(%Endpoint{token: _}, id), do: Server.delete(Role, id)
 
   def add_permission(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def add_permission(%Endpoint{}, role, permission) do

--- a/lib/cog_api/fake/roles.ex
+++ b/lib/cog_api/fake/roles.ex
@@ -45,7 +45,7 @@ defmodule CogApi.Fake.Roles do
       role = %{role | permissions: role.permissions ++ [found_permission]}
       {:ok, Server.update(Role, role.id, role) |> prepare_role}
     else
-      {:error, ["Not found permissions - #{Permission.full_name(permission)}"]}
+      return_error("Not found permissions - #{Permission.full_name(permission)}")
     end
   end
 

--- a/lib/cog_api/fake/rules.ex
+++ b/lib/cog_api/fake/rules.ex
@@ -27,13 +27,7 @@ defmodule CogApi.Fake.Rules do
   end
 
   def delete(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint
-  def delete(id, %Endpoint{token: _}) do
-    if Server.show(Rule, id) do
-      Server.delete(Rule, id)
-    else
-      {:error, ["The rule could not be deleted"]}
-    end
-  end
+  def delete(id, %Endpoint{token: _}), do: Server.delete(Rule, id)
 
   defp extract_command(rule) do
     command_pattern = ~r/\w*:\w*/

--- a/lib/cog_api/fake/server.ex
+++ b/lib/cog_api/fake/server.ex
@@ -1,4 +1,6 @@
 defmodule CogApi.Fake.Server do
+  import CogApi.Fake.Helpers, only: [return_error: 1]
+
   defstruct [
     bundles: [],
     chat_handles: [],
@@ -88,7 +90,7 @@ defmodule CogApi.Fake.Server do
         end)
       end)
     else
-      {:error, [not_found_error(module)]}
+      module |> not_found_error |> return_error
     end
   end
 

--- a/lib/cog_api/fake/server.ex
+++ b/lib/cog_api/fake/server.ex
@@ -81,11 +81,19 @@ defmodule CogApi.Fake.Server do
   end
 
   def delete(module, id) do
-    Agent.update(__MODULE__, fn server ->
-      Map.update!(server, module.fake_key, fn list ->
-        delete_by_id(list, id)
+    if show(module, id) do
+      Agent.update(__MODULE__, fn server ->
+        Map.update!(server, module.fake_key, fn list ->
+          delete_by_id(list, id)
+        end)
       end)
-    end)
+    else
+      {:error, [not_found_error(module)]}
+    end
+  end
+
+  def not_found_error(module) do
+    "Resource not found for: #{module.fake_key}"
   end
 
   defp update_by_id(list, id, params) do

--- a/lib/cog_api/fake/triggers.ex
+++ b/lib/cog_api/fake/triggers.ex
@@ -50,10 +50,6 @@ defmodule CogApi.Fake.Triggers do
     end
   end
 
-  def delete(%Endpoint{token: nil}, _, _),
-    do: Endpoint.invalid_endpoint
-  def delete(%Endpoint{token: _}, id) do
-    Server.delete(Trigger, id)
-    :ok
-  end
+  def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
+  def delete(%Endpoint{token: _}, id), do: Server.delete(Trigger, id)
 end

--- a/lib/cog_api/fake/users.ex
+++ b/lib/cog_api/fake/users.ex
@@ -35,9 +35,6 @@ defmodule CogApi.Fake.Users do
     end
   end
 
-  def delete(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
-  def delete(%Endpoint{token: _}, id) do
-    Server.delete(User, id)
-    :ok
-  end
+  def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
+  def delete(%Endpoint{token: _}, id), do: Server.delete(User, id)
 end

--- a/test/support/fake_helpers.ex
+++ b/test/support/fake_helpers.ex
@@ -2,13 +2,13 @@ defmodule CogApi.Test.FakeHelpers do
   alias CogApi.Endpoint
   alias CogApi.Fake.Client
 
-  def fake_endpoint do
+  def valid_endpoint do
     {:ok, endpoint} = %Endpoint{} |> Client.authenticate
     endpoint
   end
 
   def create_bundle(params \\ %{}) do
-    {:ok, bundle} = Client.bundle_create(fake_endpoint, minimal_bundle_config(params))
+    {:ok, bundle} = Client.bundle_create(valid_endpoint, minimal_bundle_config(params))
     bundle
   end
 

--- a/test/unit/cog_api/fake/authentication_test.exs
+++ b/test/unit/cog_api/fake/authentication_test.exs
@@ -14,7 +14,7 @@ defmodule CogApi.Fake.AuthenticationTest do
           host: "localhost",
           port: "4000",
         }
-        Client.user_create(fake_endpoint, %{username: "admin"})
+        Client.user_create(valid_endpoint, %{username: "admin"})
         {:ok, updated_endpoint} = Authentication.get_and_merge_token(endpoint)
 
         assert present updated_endpoint.token

--- a/test/unit/cog_api/fake/bundles_test.exs
+++ b/test/unit/cog_api/fake/bundles_test.exs
@@ -19,7 +19,7 @@ defmodule CogApi.Fake.BundlesTest do
       bundle = %Bundle{id: "id123", name: "bundle"}
       Server.create(Bundle, bundle)
 
-      {:ok, bundles} = Client.bundle_index(fake_endpoint)
+      {:ok, bundles} = Client.bundle_index(valid_endpoint)
 
       first_bundle = List.first bundles
       assert first_bundle.id == bundle.id
@@ -30,20 +30,20 @@ defmodule CogApi.Fake.BundlesTest do
   describe "bundle_show" do
     it "returns the bundle" do
       config = %{minimal_bundle_config | name: "postgres"}
-      bundle = Client.bundle_create(fake_endpoint, config) |> get_value
+      bundle = Client.bundle_create(valid_endpoint, config) |> get_value
 
-      bundle = Client.bundle_show(fake_endpoint, bundle.id) |> get_value
+      bundle = Client.bundle_show(valid_endpoint, bundle.id) |> get_value
       assert bundle.name == "postgres"
     end
 
     it "includes the rules for each command" do
       command = %CogApi.Resources.Command{name: "help"}
       config = %{minimal_bundle_config | name: "postgres", commands: [command]}
-      bundle = Client.bundle_create(fake_endpoint, config) |> get_value
+      bundle = Client.bundle_create(valid_endpoint, config) |> get_value
       rule_text = "when command is postgres:help must have operable:manage_commands"
-      rule_text |> Client.rule_create(fake_endpoint) |> get_value
+      rule_text |> Client.rule_create(valid_endpoint) |> get_value
 
-      [rule] = Client.bundle_show(fake_endpoint, bundle.id)
+      [rule] = Client.bundle_show(valid_endpoint, bundle.id)
       |> get_value
       |> Map.get(:commands)
       |> List.first
@@ -56,7 +56,7 @@ defmodule CogApi.Fake.BundlesTest do
   describe "bundle_create" do
     it "allows adding a new bundle" do
       config = minimal_bundle_config
-      bundle = Client.bundle_create(fake_endpoint, config) |> get_value
+      bundle = Client.bundle_create(valid_endpoint, config) |> get_value
 
       assert bundle.name == "bundle"
       command = List.first(bundle.commands)
@@ -67,7 +67,7 @@ defmodule CogApi.Fake.BundlesTest do
 
     it "works with string keys" do
       config = to_string_keys(minimal_bundle_config)
-      bundle = Client.bundle_create(fake_endpoint, config) |> get_value
+      bundle = Client.bundle_create(valid_endpoint, config) |> get_value
 
       assert bundle.name == "bundle"
       command = List.first(bundle.commands)
@@ -76,7 +76,7 @@ defmodule CogApi.Fake.BundlesTest do
     end
 
     it "fails without valid info" do
-      {:error, errors} = Client.bundle_create(fake_endpoint, %{})
+      {:error, errors} = Client.bundle_create(valid_endpoint, %{})
       assert errors == ["Invalid bundle config"]
     end
   end
@@ -84,10 +84,10 @@ defmodule CogApi.Fake.BundlesTest do
   describe "bundle_update" do
     it "returns the updated bundle" do
       config = minimal_bundle_config
-      bundle = Client.bundle_create(fake_endpoint, config) |> get_value
+      bundle = Client.bundle_create(valid_endpoint, config) |> get_value
 
       {:ok, updated_bundle} = Client.bundle_update(
-        fake_endpoint,
+        valid_endpoint,
         bundle.id,
         %{enabled: false}
       )
@@ -97,10 +97,10 @@ defmodule CogApi.Fake.BundlesTest do
 
     it "will allow a string for enabled" do
       config = minimal_bundle_config
-      bundle = Client.bundle_create(fake_endpoint, config) |> get_value
+      bundle = Client.bundle_create(valid_endpoint, config) |> get_value
 
       {:ok, updated_bundle} = Client.bundle_update(
-        fake_endpoint,
+        valid_endpoint,
         bundle.id,
         %{enabled: "true"}
       )
@@ -112,7 +112,7 @@ defmodule CogApi.Fake.BundlesTest do
       Server.create(Bundle, bundle)
 
       {:error, [error]} = Client.bundle_update(
-        fake_endpoint,
+        valid_endpoint,
         bundle.id,
         %{id: "1234", name: "not a bundle"}
       )
@@ -122,10 +122,10 @@ defmodule CogApi.Fake.BundlesTest do
 
     it "allows a way to test errors" do
       config = minimal_bundle_config
-      bundle = Client.bundle_create(fake_endpoint, config) |> get_value
+      bundle = Client.bundle_create(valid_endpoint, config) |> get_value
 
       {:error, [error]} = Client.bundle_update(
-        fake_endpoint,
+        valid_endpoint,
         bundle.id,
         %{enabled: "ERROR"}
       )
@@ -135,10 +135,10 @@ defmodule CogApi.Fake.BundlesTest do
 
     it "returns the updated bundle given a bundle name" do
       config = minimal_bundle_config
-      bundle = Client.bundle_create(fake_endpoint, config) |> get_value
+      bundle = Client.bundle_create(valid_endpoint, config) |> get_value
 
       {:ok, updated_bundle} = Client.bundle_update(
-        fake_endpoint,
+        valid_endpoint,
         %{name: bundle.name},
         %{enabled: "false"}
       )
@@ -150,17 +150,17 @@ defmodule CogApi.Fake.BundlesTest do
   describe "bundle_delete" do
     it "returns :ok" do
       config = minimal_bundle_config
-      bundle = Client.bundle_create(fake_endpoint, config) |> get_value
+      bundle = Client.bundle_create(valid_endpoint, config) |> get_value
 
       assert :ok == Client.bundle_delete(
-        fake_endpoint,
+        valid_endpoint,
         bundle.id
       )
     end
 
     context "when the bundle cannot be deleted" do
       it "returns an error" do
-        {:error, [error]} = Client.bundle_delete(fake_endpoint, "not real")
+        {:error, [error]} = Client.bundle_delete(valid_endpoint, "not real")
 
         assert error == "Resource not found for: bundles"
       end

--- a/test/unit/cog_api/fake/bundles_test.exs
+++ b/test/unit/cog_api/fake/bundles_test.exs
@@ -111,7 +111,7 @@ defmodule CogApi.Fake.BundlesTest do
       bundle = %Bundle{id: "id123", name: "a bundle", enabled: true}
       Server.create(Bundle, bundle)
 
-      {:error, error} = Client.bundle_update(
+      {:error, [error]} = Client.bundle_update(
         fake_endpoint,
         bundle.id,
         %{id: "1234", name: "not a bundle"}

--- a/test/unit/cog_api/fake/bundles_test.exs
+++ b/test/unit/cog_api/fake/bundles_test.exs
@@ -162,7 +162,7 @@ defmodule CogApi.Fake.BundlesTest do
       it "returns an error" do
         {:error, [error]} = Client.bundle_delete(fake_endpoint, "not real")
 
-        assert error == "The bundle could not be deleted"
+        assert error == "Resource not found for: bundles"
       end
     end
   end

--- a/test/unit/cog_api/fake/chat_handles_test.exs
+++ b/test/unit/cog_api/fake/chat_handles_test.exs
@@ -8,7 +8,7 @@ defmodule CogApi.Fake.ChatHandlesTest do
 
   describe "chat_handles_create" do
     it "allows creating a new chat handle for a user" do
-      endpoint = fake_endpoint
+      endpoint = valid_endpoint
       user = find_or_create_user(endpoint, "chat_handles_create")
 
       handle = Client.chat_handle_create(
@@ -23,7 +23,7 @@ defmodule CogApi.Fake.ChatHandlesTest do
 
     context "when the chat handle does not exist for the provider" do
       it "returns an error" do
-        endpoint = fake_endpoint
+        endpoint = valid_endpoint
         user = find_or_create_user(endpoint, "chat_handles_create_no_handle")
 
         {:error, [error]} = Client.chat_handle_create(
@@ -39,7 +39,7 @@ defmodule CogApi.Fake.ChatHandlesTest do
 
   describe "chat_handles_delete" do
     it "allows deleting a chat handle" do
-      endpoint = fake_endpoint
+      endpoint = valid_endpoint
       user = find_or_create_user(endpoint, "chat_handles_delete")
       handle = Client.chat_handle_create(
         endpoint,
@@ -62,20 +62,20 @@ defmodule CogApi.Fake.ChatHandlesTest do
         username: "chief_of_staff",
         password: "supersecret",
       }
-      user = Client.user_create(fake_endpoint, params) |> get_value
+      user = Client.user_create(valid_endpoint, params) |> get_value
       handle = Client.chat_handle_create(
-        fake_endpoint,
+        valid_endpoint,
         user.id,
         %{chat_provider: "slack", handle: "bar"}
       ) |> get_value
 
       _other_handle = Client.chat_handle_create(
-        fake_endpoint,
+        valid_endpoint,
         "other-user-id",
         %{chat_provider: "slack", handle: "foo"}
       ) |> get_value
 
-      chat_handles = Client.chat_handle_for_user(user.id, fake_endpoint) |> get_value
+      chat_handles = Client.chat_handle_for_user(user.id, valid_endpoint) |> get_value
       assert chat_handles == [handle]
     end
   end

--- a/test/unit/cog_api/fake/groups_test.exs
+++ b/test/unit/cog_api/fake/groups_test.exs
@@ -79,7 +79,7 @@ defmodule CogApi.Fake.GroupsTest do
       it "returns an error" do
         {:error, [error]} = Client.group_delete(fake_endpoint, "not real")
 
-        assert error == "The group could not be deleted"
+        assert error == "Resource not found for: groups"
       end
     end
   end

--- a/test/unit/cog_api/fake/groups_test.exs
+++ b/test/unit/cog_api/fake/groups_test.exs
@@ -9,9 +9,9 @@ defmodule CogApi.Fake.GroupsTest do
   describe "group_index" do
     it "returns a list of groups" do
       name = "foobar"
-      {:ok, _ } = Client.group_create(fake_endpoint, %{name: name})
+      {:ok, _ } = Client.group_create(valid_endpoint, %{name: name})
 
-      {:ok, groups} = Client.group_index(fake_endpoint)
+      {:ok, groups} = Client.group_index(valid_endpoint)
 
       first_group = List.first groups
       assert present first_group.id
@@ -23,9 +23,9 @@ defmodule CogApi.Fake.GroupsTest do
     context "when the group exists" do
       it "returns the group" do
         params = %{name: "Developers"}
-        {:ok, created_group} = Client.group_create(fake_endpoint, params)
+        {:ok, created_group} = Client.group_create(valid_endpoint, params)
 
-        {:ok, found_group} = Client.group_show(fake_endpoint, created_group.id)
+        {:ok, found_group} = Client.group_show(valid_endpoint, created_group.id)
 
         assert found_group.id == created_group.id
       end
@@ -35,8 +35,8 @@ defmodule CogApi.Fake.GroupsTest do
   describe "group_find" do
     it "finds and returns a group by name" do
       group_names = ~w(group_1 group_2 group_3)
-      Enum.each(group_names, fn(name) -> Client.group_create(fake_endpoint, %{name: name}) end)
-      {:ok, group} = Client.group_find(fake_endpoint, name: Enum.at(group_names, 1))
+      Enum.each(group_names, fn(name) -> Client.group_create(valid_endpoint, %{name: name}) end)
+      {:ok, group} = Client.group_find(valid_endpoint, name: Enum.at(group_names, 1))
 
       assert present group.id
       assert group.name == Enum.at(group_names, 1)
@@ -46,7 +46,7 @@ defmodule CogApi.Fake.GroupsTest do
   describe "create" do
     it "returns the created group" do
       name = "foobar"
-      {:ok, group} = Client.group_create(fake_endpoint, %{name: name})
+      {:ok, group} = Client.group_create(valid_endpoint, %{name: name})
 
       assert present group.id
       assert group.name == name
@@ -57,7 +57,7 @@ defmodule CogApi.Fake.GroupsTest do
     it "updates the group on the server and returns the updated group" do
       name = "foobar"
 
-      {:ok, group} = Client.group_create(fake_endpoint, %{name: name})
+      {:ok, group} = Client.group_create(valid_endpoint, %{name: name})
 
       assert present group.id
       assert group.name == name
@@ -66,18 +66,18 @@ defmodule CogApi.Fake.GroupsTest do
 
   describe "delete" do
     it "deletes the group from the server" do
-      {:ok, group} = Client.group_create(fake_endpoint, %{name: "new group"})
+      {:ok, group} = Client.group_create(valid_endpoint, %{name: "new group"})
 
-      assert :ok == Client.group_delete(fake_endpoint, group.id)
+      assert :ok == Client.group_delete(valid_endpoint, group.id)
 
-      {:ok, groups} = Client.group_index(fake_endpoint)
+      {:ok, groups} = Client.group_index(valid_endpoint)
 
       refute Enum.member?(groups, group)
     end
 
     context "when the group cannot be deleted" do
       it "returns an error" do
-        {:error, [error]} = Client.group_delete(fake_endpoint, "not real")
+        {:error, [error]} = Client.group_delete(valid_endpoint, "not real")
 
         assert error == "Resource not found for: groups"
       end
@@ -86,10 +86,10 @@ defmodule CogApi.Fake.GroupsTest do
 
   describe "group_add_role" do
     it "returns the roles that are associated with that group" do
-      role = Client.role_create(fake_endpoint, %{name: "role"}) |> get_value
-      group = Client.group_create(fake_endpoint, %{name: "group"}) |> get_value
+      role = Client.role_create(valid_endpoint, %{name: "role"}) |> get_value
+      group = Client.group_create(valid_endpoint, %{name: "group"}) |> get_value
 
-      updated_group = Client.group_add_role(fake_endpoint, %Group{id: group.id}, role) |> get_value
+      updated_group = Client.group_add_role(valid_endpoint, %Group{id: group.id}, role) |> get_value
 
       first_role = List.first updated_group.roles
       assert updated_group.name == group.name
@@ -99,12 +99,12 @@ defmodule CogApi.Fake.GroupsTest do
 
   describe "group_remove_role" do
     it "returns the roles that are associated with that group" do
-      role = Client.role_create(fake_endpoint, %{name: "role123"}) |> get_value
-      group = Client.group_create(fake_endpoint, %{name: "group123"}) |> get_value
-      group = Client.group_add_role(fake_endpoint, group, role) |> get_value
+      role = Client.role_create(valid_endpoint, %{name: "role123"}) |> get_value
+      group = Client.group_create(valid_endpoint, %{name: "group123"}) |> get_value
+      group = Client.group_add_role(valid_endpoint, group, role) |> get_value
       assert group.roles != []
 
-      updated_group = Client.group_remove_role(fake_endpoint, %Group{id: group.id}, role) |> get_value
+      updated_group = Client.group_remove_role(valid_endpoint, %Group{id: group.id}, role) |> get_value
 
       assert updated_group.name == group.name
       assert updated_group.roles == []
@@ -113,33 +113,33 @@ defmodule CogApi.Fake.GroupsTest do
 
   describe "group_add_user" do
     it "adds the user to the group" do
-      group = Client.group_create(fake_endpoint, %{name: "user_group"}) |> get_value
-      first_user = Client.user_create(fake_endpoint, %{email_address: "bob@example.com"}) |> get_value
-      second_user = Client.user_create(fake_endpoint, %{email_address: "sam@example.com"}) |> get_value
+      group = Client.group_create(valid_endpoint, %{name: "user_group"}) |> get_value
+      first_user = Client.user_create(valid_endpoint, %{email_address: "bob@example.com"}) |> get_value
+      second_user = Client.user_create(valid_endpoint, %{email_address: "sam@example.com"}) |> get_value
       assert group.users == []
 
-      {:ok, group} = Client.group_add_user(fake_endpoint, group, first_user)
-      {:ok, group} = Client.group_add_user(fake_endpoint, group, second_user)
+      {:ok, group} = Client.group_add_user(valid_endpoint, group, first_user)
+      {:ok, group} = Client.group_add_user(valid_endpoint, group, second_user)
 
       assert ids_for(group.users) == [first_user.id, second_user.id]
 
-      first_user = Client.user_show(fake_endpoint, first_user.id) |> get_value
+      first_user = Client.user_show(valid_endpoint, first_user.id) |> get_value
       assert ids_for(first_user.groups) == [group.id]
 
-      second_user = Client.user_show(fake_endpoint, second_user.id) |> get_value
+      second_user = Client.user_show(valid_endpoint, second_user.id) |> get_value
       assert ids_for(second_user.groups) == [group.id]
     end
   end
 
   describe "group_remove_user" do
     it "removes the user from the group" do
-      {group, user} = create_group_with_user(fake_endpoint)
+      {group, user} = create_group_with_user(valid_endpoint)
 
-      {:ok, group} = Client.group_remove_user(fake_endpoint, group, user)
+      {:ok, group} = Client.group_remove_user(valid_endpoint, group, user)
 
       assert group.users == []
 
-      user = Client.user_show(fake_endpoint, user.id) |> get_value
+      user = Client.user_show(valid_endpoint, user.id) |> get_value
       assert user.groups == []
     end
   end

--- a/test/unit/cog_api/fake/permissions_test.exs
+++ b/test/unit/cog_api/fake/permissions_test.exs
@@ -7,9 +7,9 @@ defmodule CogApi.Fake.PermissionsTest do
 
   describe "permission_index" do
     it "returns a list of permissions" do
-      {:ok, _ } = Client.permission_create(fake_endpoint, "custom:foobar")
+      {:ok, _ } = Client.permission_create(valid_endpoint, "custom:foobar")
 
-      {:ok, permissions} = Client.permission_index(fake_endpoint)
+      {:ok, permissions} = Client.permission_index(valid_endpoint)
 
       first_permission = List.first permissions
       assert present first_permission.id
@@ -21,7 +21,7 @@ defmodule CogApi.Fake.PermissionsTest do
   describe "permission_create" do
     it "defaults to the site namespace when no `:` is given" do
       name = "view_all_things"
-      {:ok, permission} = Client.permission_create(fake_endpoint, name)
+      {:ok, permission} = Client.permission_create(valid_endpoint, name)
 
       assert present permission.id
       assert permission.name == "view_all_things"
@@ -30,7 +30,7 @@ defmodule CogApi.Fake.PermissionsTest do
 
     it "allows creating permissions in specifc namespaces" do
       name = "custom:foobar"
-      {:ok, permission} = Client.permission_create(fake_endpoint, name)
+      {:ok, permission} = Client.permission_create(valid_endpoint, name)
 
       assert present permission.id
       assert permission.name == "foobar"
@@ -40,7 +40,7 @@ defmodule CogApi.Fake.PermissionsTest do
 
   describe "permission_delete" do
     it "allows deleting permissions in the site namespace" do
-      endpoint = fake_endpoint
+      endpoint = valid_endpoint
       name = "permission_delete"
       permission = Client.permission_create(endpoint, name) |> get_value
 
@@ -49,7 +49,7 @@ defmodule CogApi.Fake.PermissionsTest do
 
     context "when the permission is not in the site namespace" do
       it "returns an error" do
-        endpoint = fake_endpoint
+        endpoint = valid_endpoint
         name = "operable:manage_comamnds"
         manage_commands_permission = Client.permission_create(endpoint, name)
         |> get_value

--- a/test/unit/cog_api/fake/relay_groups_test.exs
+++ b/test/unit/cog_api/fake/relay_groups_test.exs
@@ -8,9 +8,9 @@ defmodule CogApi.Fake.RelayGroupsTest do
   describe "relay_group_index" do
     it "returns a list of relay groups" do
       name = "Index Group"
-      {:ok, _} = Client.relay_group_create(%{name: "Index Group"}, fake_endpoint)
+      {:ok, _} = Client.relay_group_create(%{name: "Index Group"}, valid_endpoint)
 
-      groups = Client.relay_group_index(fake_endpoint) |> get_value
+      groups = Client.relay_group_index(valid_endpoint) |> get_value
 
       last_group = List.last groups
       assert present last_group.id
@@ -23,9 +23,9 @@ defmodule CogApi.Fake.RelayGroupsTest do
   describe "relay_group_show" do
     it "returns a list of relay groups" do
       name = "Show"
-      created_group = Client.relay_group_create(%{name: name}, fake_endpoint) |> get_value
+      created_group = Client.relay_group_create(%{name: name}, valid_endpoint) |> get_value
 
-      found_group = Client.relay_group_show(created_group.id, fake_endpoint) |> get_value
+      found_group = Client.relay_group_show(created_group.id, valid_endpoint) |> get_value
 
       assert created_group.id == found_group.id
       assert created_group.name == found_group.name
@@ -34,9 +34,9 @@ defmodule CogApi.Fake.RelayGroupsTest do
     context "when passing relay group name" do
       it "returns a relay group" do
         name = "ShowName"
-        created_group = Client.relay_group_create(%{name: name}, fake_endpoint) |> get_value
+        created_group = Client.relay_group_create(%{name: name}, valid_endpoint) |> get_value
 
-        found_group = Client.relay_group_show(%{name: created_group.name}, fake_endpoint) |> get_value
+        found_group = Client.relay_group_show(%{name: created_group.name}, valid_endpoint) |> get_value
 
         assert created_group.id == found_group.id
         assert created_group.name == found_group.name
@@ -47,7 +47,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
   describe "relay_group_create" do
     it "returns the created relay group" do
       name = "new group"
-      {:ok, relay_group} = Client.relay_group_create(%{name: name}, fake_endpoint)
+      {:ok, relay_group} = Client.relay_group_create(%{name: name}, valid_endpoint)
 
       assert present relay_group.id
       assert relay_group.name == name
@@ -57,7 +57,7 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
     context "when given invalid params" do
       it "returns a list of errors" do
-        {:error, [error]} = Client.relay_group_create(%{name: "ERROR"}, fake_endpoint)
+        {:error, [error]} = Client.relay_group_create(%{name: "ERROR"}, valid_endpoint)
 
         assert error == "Name is invalid"
       end
@@ -66,11 +66,11 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
   describe "relay_group_updated" do
     it "returns the updated relay group" do
-      {:ok, new_relay_group} = Client.relay_group_create(%{name: "relay_group_update"}, fake_endpoint)
+      {:ok, new_relay_group} = Client.relay_group_create(%{name: "relay_group_update"}, valid_endpoint)
       {:ok, updated} = Client.relay_group_update(
         new_relay_group.id,
         %{name: "updated"},
-        fake_endpoint
+        valid_endpoint
       )
 
       assert updated.name == "updated"
@@ -78,11 +78,11 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
     context "when given invalid params" do
       it "returns a list of errors" do
-        {:ok, relay_group} = Client.relay_group_create(%{name: "name"}, fake_endpoint)
+        {:ok, relay_group} = Client.relay_group_create(%{name: "name"}, valid_endpoint)
         {:error, [error]} = Client.relay_group_update(
           relay_group.id,
           %{name: "ERROR"},
-          fake_endpoint
+          valid_endpoint
         )
 
         assert error == "Name is invalid"
@@ -92,13 +92,13 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
   describe "relay_group_delete" do
     it "returns :ok" do
-      {:ok, relay_group} = Client.relay_group_create(%{name: "delete me"}, fake_endpoint)
-      assert :ok == Client.relay_group_delete(relay_group.id, fake_endpoint)
+      {:ok, relay_group} = Client.relay_group_create(%{name: "delete me"}, valid_endpoint)
+      assert :ok == Client.relay_group_delete(relay_group.id, valid_endpoint)
     end
 
     context "when the relay group cannot be deleted" do
       it "returns an error" do
-        {:error, [error]} = Client.relay_group_delete("not real", fake_endpoint)
+        {:error, [error]} = Client.relay_group_delete("not real", valid_endpoint)
 
         assert error == "The relay group could not be deleted"
       end
@@ -106,24 +106,24 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
     context "when given the relay group name" do
       it "returns :ok" do
-        {:ok, relay_group} = Client.relay_group_create(%{name: "nada"}, fake_endpoint)
-        assert :ok == Client.relay_group_delete(%{name: relay_group.name}, fake_endpoint)
+        {:ok, relay_group} = Client.relay_group_create(%{name: "nada"}, valid_endpoint)
+        assert :ok == Client.relay_group_delete(%{name: relay_group.name}, valid_endpoint)
       end
     end
   end
 
   describe "relay_group_add_relay" do
     it "adds the relay to the group" do
-      relay = Client.relay_create(%{name: "relayyy", token: "1234"}, fake_endpoint) |> get_value
-      group = Client.relay_group_create(%{name: "groupyy"}, fake_endpoint) |> get_value
+      relay = Client.relay_create(%{name: "relayyy", token: "1234"}, valid_endpoint) |> get_value
+      group = Client.relay_group_create(%{name: "groupyy"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_relay(group.id, relay.id, fake_endpoint) |> get_value
+      group = Client.relay_group_add_relay(group.id, relay.id, valid_endpoint) |> get_value
 
       [grouped_relay] = group.relays
 
       assert grouped_relay.id == relay.id
 
-      first_group = Client.relay_show(relay.id, fake_endpoint)
+      first_group = Client.relay_show(relay.id, valid_endpoint)
         |> get_value
         |> Map.get(:groups)
         |> List.first
@@ -132,14 +132,14 @@ defmodule CogApi.Fake.RelayGroupsTest do
     end
 
     it "handles a relay that was externally updated" do
-      relay = Client.relay_create(%{name: "original_name", token: "1234"}, fake_endpoint) |> get_value
-      group = Client.relay_group_create(%{name: "group"}, fake_endpoint) |> get_value
-      group = Client.relay_group_add_relay(group.id, relay.id, fake_endpoint) |> get_value
+      relay = Client.relay_create(%{name: "original_name", token: "1234"}, valid_endpoint) |> get_value
+      group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
+      group = Client.relay_group_add_relay(group.id, relay.id, valid_endpoint) |> get_value
 
       new_name = "updated_name"
-      Client.relay_update(relay.id, %{name: new_name}, fake_endpoint)
+      Client.relay_update(relay.id, %{name: new_name}, valid_endpoint)
 
-      group = Client.relay_group_show(group.id, fake_endpoint) |> get_value
+      group = Client.relay_group_show(group.id, valid_endpoint) |> get_value
       [relay_name] = group.relays |> Enum.map(fn relay -> relay.name end)
 
       assert relay_name == new_name
@@ -147,16 +147,16 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
     context "when given the relay group name" do
       it "adds the relay to the group" do
-        relay = Client.relay_create(%{name: "relay1", token: "1234"}, fake_endpoint) |> get_value
-        group = Client.relay_group_create(%{name: "mygroup"}, fake_endpoint) |> get_value
+        relay = Client.relay_create(%{name: "relay1", token: "1234"}, valid_endpoint) |> get_value
+        group = Client.relay_group_create(%{name: "mygroup"}, valid_endpoint) |> get_value
 
-        group = Client.relay_group_add_relay(%{name: group.name}, %{relay: relay.name}, fake_endpoint) |> get_value
+        group = Client.relay_group_add_relay(%{name: group.name}, %{relay: relay.name}, valid_endpoint) |> get_value
 
         [grouped_relay] = group.relays
 
         assert grouped_relay.id == relay.id
 
-        first_group = Client.relay_show(relay.id, fake_endpoint)
+        first_group = Client.relay_show(relay.id, valid_endpoint)
         |> get_value
         |> Map.get(:groups)
         |> List.first
@@ -168,16 +168,16 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
   describe "relay_group_remove_relay" do
     it "removes the relay from the group" do
-      relay = Client.relay_create(%{name: "relayyy", token: "1234"}, fake_endpoint) |> get_value
-      group = Client.relay_group_create(%{name: "groupyy"}, fake_endpoint) |> get_value
-      group = Client.relay_group_add_relay(group.id, relay.id, fake_endpoint) |> get_value
+      relay = Client.relay_create(%{name: "relayyy", token: "1234"}, valid_endpoint) |> get_value
+      group = Client.relay_group_create(%{name: "groupyy"}, valid_endpoint) |> get_value
+      group = Client.relay_group_add_relay(group.id, relay.id, valid_endpoint) |> get_value
       assert group.relays != []
 
-      group = Client.relay_group_remove_relay(group.id, relay.id, fake_endpoint) |> get_value
+      group = Client.relay_group_remove_relay(group.id, relay.id, valid_endpoint) |> get_value
 
       assert group.relays == []
 
-      relay_groups = Client.relay_show(relay.id, fake_endpoint)
+      relay_groups = Client.relay_show(relay.id, valid_endpoint)
         |> get_value
         |> Map.get(:groups)
       assert relay_groups == []
@@ -185,16 +185,16 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
     context "when given the relay group name" do
       it "reomves the relay from the group" do
-        relay = Client.relay_create(%{name: "relay2", token: "1234"}, fake_endpoint) |> get_value
-        group = Client.relay_group_create(%{name: "my-relays"}, fake_endpoint) |> get_value
-        group = Client.relay_group_add_relay(group.id, relay.id, fake_endpoint) |> get_value
+        relay = Client.relay_create(%{name: "relay2", token: "1234"}, valid_endpoint) |> get_value
+        group = Client.relay_group_create(%{name: "my-relays"}, valid_endpoint) |> get_value
+        group = Client.relay_group_add_relay(group.id, relay.id, valid_endpoint) |> get_value
         assert group.relays != []
 
-        group = Client.relay_group_remove_relay(%{name: group.name}, %{relay: relay.name}, fake_endpoint) |> get_value
+        group = Client.relay_group_remove_relay(%{name: group.name}, %{relay: relay.name}, valid_endpoint) |> get_value
 
         assert group.relays == []
 
-        relay_groups = Client.relay_show(relay.id, fake_endpoint)
+        relay_groups = Client.relay_show(relay.id, valid_endpoint)
         |> get_value
         |> Map.get(:groups)
         assert relay_groups == []
@@ -205,15 +205,15 @@ defmodule CogApi.Fake.RelayGroupsTest do
   describe "relay_group_add_bundle" do
     it "adds the bundle to the group" do
       bundle = create_bundle
-      group = Client.relay_group_create(%{name: "group"}, fake_endpoint) |> get_value
+      group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_bundles(group.id, bundle.id, fake_endpoint) |> get_value
+      group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint) |> get_value
 
       [grouped_bundle] = group.bundles
 
       assert grouped_bundle.id == bundle.id
 
-      first_group = Client.bundle_show(fake_endpoint, bundle.id)
+      first_group = Client.bundle_show(valid_endpoint, bundle.id)
         |> get_value
         |> Map.get(:relay_groups)
         |> List.first
@@ -225,9 +225,9 @@ defmodule CogApi.Fake.RelayGroupsTest do
       bundle_ids = Enum.map(1..5, &create_bundle(%{name: "bundle#{&1}"}))
       |> Enum.map(&Map.fetch!(&1, :id))
 
-      group = Client.relay_group_create(%{name: "group"}, fake_endpoint) |> get_value
+      group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_bundles(group.id, bundle_ids, fake_endpoint) |> get_value
+      group = Client.relay_group_add_bundles(group.id, bundle_ids, valid_endpoint) |> get_value
 
       returned_bundle_ids = MapSet.new(group.bundles, &Map.fetch!(&1, :id))
       intersection = MapSet.intersection(MapSet.new(bundle_ids), returned_bundle_ids)
@@ -243,12 +243,12 @@ defmodule CogApi.Fake.RelayGroupsTest do
 
     it "handles a bundle that was externally updated" do
       bundle = create_bundle(%{enabled: false})
-      group = Client.relay_group_create(%{name: "group"}, fake_endpoint) |> get_value
-      group = Client.relay_group_add_bundles(group.id, bundle.id, fake_endpoint) |> get_value
+      group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
+      group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint) |> get_value
 
-      Client.bundle_update(fake_endpoint, bundle.id, %{enabled: "true"})
+      Client.bundle_update(valid_endpoint, bundle.id, %{enabled: "true"})
 
-      group = Client.relay_group_show(group.id, fake_endpoint) |> get_value
+      group = Client.relay_group_show(group.id, valid_endpoint) |> get_value
       [bundle_enabled] = group.bundles |> Enum.map(&(&1.enabled))
 
       assert bundle_enabled == true
@@ -257,13 +257,13 @@ defmodule CogApi.Fake.RelayGroupsTest do
     context "when passed names" do
       it "adds the bundle to the relay group" do
         bundle = create_bundle
-        group = Client.relay_group_create(%{name: "my-relays"}, fake_endpoint) |> get_value
-        group = Client.relay_group_add_bundles(%{name: group.name}, %{bundles: [bundle.name]}, fake_endpoint) |> get_value
+        group = Client.relay_group_create(%{name: "my-relays"}, valid_endpoint) |> get_value
+        group = Client.relay_group_add_bundles(%{name: group.name}, %{bundles: [bundle.name]}, valid_endpoint) |> get_value
         [grouped_bundle] = group.bundles
 
         assert grouped_bundle.id == bundle.id
 
-        relay_group = Client.bundle_show(fake_endpoint, bundle.id)
+        relay_group = Client.bundle_show(valid_endpoint, bundle.id)
         |> get_value
         |> Map.get(:relay_groups)
         |> List.first
@@ -276,9 +276,9 @@ defmodule CogApi.Fake.RelayGroupsTest do
         bundle_names = Enum.map(bundles, &Map.fetch!(&1, :name))
         bundle_ids = Enum.map(bundles, &Map.fetch!(&1, :id))
 
-        group = Client.relay_group_create(%{name: "group"}, fake_endpoint) |> get_value
+        group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-        group = Client.relay_group_add_bundles(%{name: group.name}, %{bundles: bundle_names}, fake_endpoint) |> get_value
+        group = Client.relay_group_add_bundles(%{name: group.name}, %{bundles: bundle_names}, valid_endpoint) |> get_value
 
         returned_bundle_ids = MapSet.new(group.bundles, &Map.fetch!(&1, :id))
         intersection = MapSet.intersection(MapSet.new(bundle_ids), returned_bundle_ids)
@@ -297,15 +297,15 @@ defmodule CogApi.Fake.RelayGroupsTest do
   describe "relay_group_remove_bundle" do
     it "removes the bundle from the group" do
       bundle = create_bundle
-      group = Client.relay_group_create(%{name: "group"}, fake_endpoint) |> get_value
-      group = Client.relay_group_add_bundles(group.id, bundle.id, fake_endpoint) |> get_value
+      group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
+      group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint) |> get_value
       assert group.bundles != []
 
-      group = Client.relay_group_remove_bundles(group.id, bundle.id, fake_endpoint) |> get_value
+      group = Client.relay_group_remove_bundles(group.id, bundle.id, valid_endpoint) |> get_value
 
       assert group.bundles == []
 
-      relay_groups = Client.bundle_show(fake_endpoint, bundle.id)
+      relay_groups = Client.bundle_show(valid_endpoint, bundle.id)
         |> get_value
         |> Map.get(:relay_groups)
       assert relay_groups == []
@@ -315,27 +315,27 @@ defmodule CogApi.Fake.RelayGroupsTest do
       bundle_ids = Enum.map(1..5, &create_bundle(%{name: "bundle#{&1}"}))
       |> Enum.map(&Map.fetch!(&1, :id))
 
-      group = Client.relay_group_create(%{name: "group"}, fake_endpoint) |> get_value
+      group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-      group = Client.relay_group_add_bundles(group.id, bundle_ids, fake_endpoint) |> get_value
+      group = Client.relay_group_add_bundles(group.id, bundle_ids, valid_endpoint) |> get_value
       assert group.bundles != []
 
-      group = Client.relay_group_remove_bundles(group.id, bundle_ids, fake_endpoint) |> get_value
+      group = Client.relay_group_remove_bundles(group.id, bundle_ids, valid_endpoint) |> get_value
       assert group.bundles == []
     end
 
     context "when passed names" do
       it "removes the bundle from the relay group" do
         bundle = create_bundle
-        group = Client.relay_group_create(%{name: "my-relays"}, fake_endpoint) |> get_value
-        group = Client.relay_group_add_bundles(group.id, bundle.id, fake_endpoint) |> get_value
+        group = Client.relay_group_create(%{name: "my-relays"}, valid_endpoint) |> get_value
+        group = Client.relay_group_add_bundles(group.id, bundle.id, valid_endpoint) |> get_value
         assert group.bundles != []
 
-        group = Client.relay_group_remove_bundles(%{name: group.name}, %{bundles: [bundle.name]}, fake_endpoint) |> get_value
+        group = Client.relay_group_remove_bundles(%{name: group.name}, %{bundles: [bundle.name]}, valid_endpoint) |> get_value
 
         assert group.bundles == []
 
-        relay_groups = Client.bundle_show(fake_endpoint, bundle.id)
+        relay_groups = Client.bundle_show(valid_endpoint, bundle.id)
         |> get_value
         |> Map.get(:relay_groups)
         assert relay_groups == []
@@ -346,12 +346,12 @@ defmodule CogApi.Fake.RelayGroupsTest do
         bundle_ids = Enum.map(bundles, &Map.fetch!(&1, :id))
         bundle_names = Enum.map(bundles, &Map.fetch!(&1, :name))
 
-        group = Client.relay_group_create(%{name: "group"}, fake_endpoint) |> get_value
+        group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
 
-        group = Client.relay_group_add_bundles(group.id, bundle_ids, fake_endpoint) |> get_value
+        group = Client.relay_group_add_bundles(group.id, bundle_ids, valid_endpoint) |> get_value
         assert group.bundles != []
 
-        group = Client.relay_group_remove_bundles(%{name: group.name}, %{bundles: bundle_names}, fake_endpoint) |> get_value
+        group = Client.relay_group_remove_bundles(%{name: group.name}, %{bundles: bundle_names}, valid_endpoint) |> get_value
         assert group.bundles == []
       end
     end

--- a/test/unit/cog_api/fake/relays_test.exs
+++ b/test/unit/cog_api/fake/relays_test.exs
@@ -133,11 +133,11 @@ defmodule CogApi.Fake.RelaysTest do
       assert :ok == Client.relay_delete(relay.id, fake_endpoint)
     end
 
-    context "when the relay  cannot be deleted" do
+    context "when the relay cannot be deleted" do
       it "returns an error" do
         {:error, [error]} = Client.relay_delete("not real", fake_endpoint)
 
-        assert error == "The relay could not be deleted"
+        assert error == "Resource not found for: relays"
       end
     end
 

--- a/test/unit/cog_api/fake/relays_test.exs
+++ b/test/unit/cog_api/fake/relays_test.exs
@@ -8,9 +8,9 @@ defmodule CogApi.Fake.RelaysTest do
   describe "relay_index" do
     it "returns a list of relays" do
       name = "Index"
-      {:ok, _} = Client.relay_create(%{name: name, token: "1234"}, fake_endpoint)
+      {:ok, _} = Client.relay_create(%{name: name, token: "1234"}, valid_endpoint)
 
-      relays = Client.relay_index(fake_endpoint) |> get_value
+      relays = Client.relay_index(valid_endpoint) |> get_value
 
       last_relay = List.last relays
 
@@ -19,11 +19,11 @@ defmodule CogApi.Fake.RelaysTest do
     end
 
     it "includes the group for the relay" do
-      relay = Client.relay_create(%{name: "relay", token: "1234"}, fake_endpoint) |> get_value
-      group = Client.relay_group_create(%{name: "group"}, fake_endpoint) |> get_value
-      group = Client.relay_group_add_relay(group.id, relay.id, fake_endpoint) |> get_value
+      relay = Client.relay_create(%{name: "relay", token: "1234"}, valid_endpoint) |> get_value
+      group = Client.relay_group_create(%{name: "group"}, valid_endpoint) |> get_value
+      group = Client.relay_group_add_relay(group.id, relay.id, valid_endpoint) |> get_value
 
-      last_relay = Client.relay_index(fake_endpoint) |> get_value |> List.last
+      last_relay = Client.relay_index(valid_endpoint) |> get_value |> List.last
 
       [relay_group] = last_relay.groups
 
@@ -34,9 +34,9 @@ defmodule CogApi.Fake.RelaysTest do
   describe "relay_show" do
     it "returns a list of relays" do
       params = %{name: "Show", token: "1234", enabled: true, description: "This is a test"}
-      created_relay = Client.relay_create(params, fake_endpoint) |> get_value
+      created_relay = Client.relay_create(params, valid_endpoint) |> get_value
 
-      found_relay = Client.relay_show(created_relay.id, fake_endpoint) |> get_value
+      found_relay = Client.relay_show(created_relay.id, valid_endpoint) |> get_value
 
       assert created_relay.id == found_relay.id
       assert created_relay.name == found_relay.name
@@ -48,9 +48,9 @@ defmodule CogApi.Fake.RelaysTest do
       it "returns a relay" do
         params = %{name: "Show", token: "1234", enabled: true,
                    description: "This is a test", inserted_at: "Some date"}
-        created_relay = Client.relay_create(params, fake_endpoint) |> get_value
+        created_relay = Client.relay_create(params, valid_endpoint) |> get_value
 
-        found_relay = Client.relay_show(%{name: created_relay.name}, fake_endpoint) |> get_value
+        found_relay = Client.relay_show(%{name: created_relay.name}, valid_endpoint) |> get_value
 
         assert created_relay.id == found_relay.id
         assert created_relay.name == found_relay.name
@@ -63,7 +63,7 @@ defmodule CogApi.Fake.RelaysTest do
   describe "relay_create" do
     it "returns the created relay" do
       name = "new relay"
-      relay = Client.relay_create(%{name: name, token: "1234"}, fake_endpoint) |> get_value
+      relay = Client.relay_create(%{name: name, token: "1234"}, valid_endpoint) |> get_value
 
       assert present relay.id
       assert relay.name == name
@@ -72,7 +72,7 @@ defmodule CogApi.Fake.RelaysTest do
     context "when given invalid params" do
       it "returns a list of errors" do
         name = "invalid relay"
-        {:error, [error]} = Client.relay_create(%{name: name, enabled: "ERROR"}, fake_endpoint)
+        {:error, [error]} = Client.relay_create(%{name: name, enabled: "ERROR"}, valid_endpoint)
 
         assert error == "Enabled is invalid"
       end
@@ -81,13 +81,13 @@ defmodule CogApi.Fake.RelaysTest do
 
   describe "relay_updated" do
     it "returns the updated relay" do
-      new_relay = Client.relay_create(%{name: "new_relay", token: "1234"}, fake_endpoint)
+      new_relay = Client.relay_create(%{name: "new_relay", token: "1234"}, valid_endpoint)
       |> get_value
 
       updated = Client.relay_update(
         new_relay.id,
         %{name: "updated"},
-        fake_endpoint
+        valid_endpoint
       ) |> get_value
 
       assert updated.name == "updated"
@@ -96,11 +96,11 @@ defmodule CogApi.Fake.RelaysTest do
     context "when given invalid params" do
       it "returns a list of errors" do
         name = "invalid update relay"
-        relay = Client.relay_create(%{name: name, token: "1234"}, fake_endpoint) |> get_value
+        relay = Client.relay_create(%{name: name, token: "1234"}, valid_endpoint) |> get_value
         {:error, [error]} = Client.relay_update(
           relay.id,
           %{name: "ERROR"},
-          fake_endpoint
+          valid_endpoint
         )
 
         assert error == "Name is invalid"
@@ -109,7 +109,7 @@ defmodule CogApi.Fake.RelaysTest do
 
     context "when given a relay name" do
       it "returns the updated relay" do
-        new_relay = Client.relay_create(%{name: "new_relay", token: "1234"}, fake_endpoint)
+        new_relay = Client.relay_create(%{name: "new_relay", token: "1234"}, valid_endpoint)
         |> get_value
 
         assert new_relay.description == nil
@@ -117,7 +117,7 @@ defmodule CogApi.Fake.RelaysTest do
         updated = Client.relay_update(
           %{name: new_relay.name},
           %{description: "Hello"},
-          fake_endpoint
+          valid_endpoint
         ) |> get_value
 
         assert updated.description == "Hello"
@@ -127,15 +127,15 @@ defmodule CogApi.Fake.RelaysTest do
 
   describe "relay_delete" do
     it "returns :ok" do
-      relay = Client.relay_create(%{name: "delete me", token: "1234"}, fake_endpoint)
+      relay = Client.relay_create(%{name: "delete me", token: "1234"}, valid_endpoint)
       |> get_value
 
-      assert :ok == Client.relay_delete(relay.id, fake_endpoint)
+      assert :ok == Client.relay_delete(relay.id, valid_endpoint)
     end
 
     context "when the relay cannot be deleted" do
       it "returns an error" do
-        {:error, [error]} = Client.relay_delete("not real", fake_endpoint)
+        {:error, [error]} = Client.relay_delete("not real", valid_endpoint)
 
         assert error == "Resource not found for: relays"
       end
@@ -143,10 +143,10 @@ defmodule CogApi.Fake.RelaysTest do
 
     context "when given a name instead of an id" do
       it "returns :ok" do
-        relay = Client.relay_create(%{name: "delete me", token: "1234"}, fake_endpoint)
+        relay = Client.relay_create(%{name: "delete me", token: "1234"}, valid_endpoint)
         |> get_value
 
-        assert :ok == Client.relay_delete(%{name: relay.name}, fake_endpoint)
+        assert :ok == Client.relay_delete(%{name: relay.name}, valid_endpoint)
       end
     end
   end

--- a/test/unit/cog_api/fake/roles_test.exs
+++ b/test/unit/cog_api/fake/roles_test.exs
@@ -17,7 +17,7 @@ defmodule CogApi.Fake.RolesTest do
     it "returns the created role" do
       name = "foobar"
       params = %{name: name}
-      {:ok, role} = Client.role_create(fake_endpoint, params)
+      {:ok, role} = Client.role_create(valid_endpoint, params)
 
       assert present role.id
       assert role.name == name
@@ -28,21 +28,21 @@ defmodule CogApi.Fake.RolesTest do
     context "when the role exists" do
       it "returns the role" do
         params = %{name: "QA Analyst"}
-        {:ok, created_role} = Client.role_create(fake_endpoint, params)
+        {:ok, created_role} = Client.role_create(valid_endpoint, params)
 
-        {:ok, found_role} = Client.role_show(fake_endpoint, created_role.id)
+        {:ok, found_role} = Client.role_show(valid_endpoint, created_role.id)
 
         assert found_role.id == created_role.id
         assert found_role.groups == []
       end
 
       it "returns the groups that are associated with that role" do
-        role = Client.role_create(fake_endpoint, %{name: "role"}) |> get_value
-        group = Client.group_create(fake_endpoint, %{name: "group"}) |> get_value
+        role = Client.role_create(valid_endpoint, %{name: "role"}) |> get_value
+        group = Client.group_create(valid_endpoint, %{name: "group"}) |> get_value
 
-        group = Client.group_add_role(fake_endpoint, group, role) |> get_value
+        group = Client.group_add_role(valid_endpoint, group, role) |> get_value
 
-        role = Client.role_show(fake_endpoint, role.id) |> get_value
+        role = Client.role_show(valid_endpoint, role.id) |> get_value
 
         assert role.groups == [group]
       end
@@ -53,9 +53,9 @@ defmodule CogApi.Fake.RolesTest do
     context "when the role exists" do
       it "returns the role" do
         params = %{name: "QA Analyst"}
-        {:ok, created_role} = Client.role_create(fake_endpoint, params)
+        {:ok, created_role} = Client.role_create(valid_endpoint, params)
 
-        {:ok, found_role} = Client.role_show(fake_endpoint, %{name: created_role.name})
+        {:ok, found_role} = Client.role_show(valid_endpoint, %{name: created_role.name})
 
         assert found_role.id == created_role.id
       end
@@ -73,9 +73,9 @@ defmodule CogApi.Fake.RolesTest do
     it "returns a list of roles" do
       name = "foobar"
       params = %{name: name}
-      {:ok, _} = Client.role_create(fake_endpoint, params)
+      {:ok, _} = Client.role_create(valid_endpoint, params)
 
-      {:ok, roles} = Client.role_index(fake_endpoint)
+      {:ok, roles} = Client.role_index(valid_endpoint)
 
       first_role = List.first roles
       assert present first_role.id
@@ -85,9 +85,9 @@ defmodule CogApi.Fake.RolesTest do
 
   describe "role_update" do
     it "returns the updated role" do
-      {:ok, new_role} = Client.role_create(fake_endpoint, %{name: "new role"})
+      {:ok, new_role} = Client.role_create(valid_endpoint, %{name: "new role"})
       {:ok, updated_role} = Client.role_update(
-        fake_endpoint,
+        valid_endpoint,
         new_role.id,
         %{name: "updated role"}
       )
@@ -98,39 +98,39 @@ defmodule CogApi.Fake.RolesTest do
 
   describe "role_delete" do
     it "deletes the role from the server" do
-      {:ok, role} = Client.role_create(fake_endpoint, %{name: "new role"})
+      {:ok, role} = Client.role_create(valid_endpoint, %{name: "new role"})
 
-      Client.role_delete(fake_endpoint, role.id)
+      Client.role_delete(valid_endpoint, role.id)
 
-      {:ok, roles} = Client.role_index(fake_endpoint)
+      {:ok, roles} = Client.role_index(valid_endpoint)
 
       refute Enum.member?(roles, role)
     end
 
     it "returns :ok" do
-      {:ok, role} = Client.role_create(fake_endpoint, %{name: "new role"})
-      assert :ok == Client.role_delete(fake_endpoint, role.id)
+      {:ok, role} = Client.role_create(valid_endpoint, %{name: "new role"})
+      assert :ok == Client.role_delete(valid_endpoint, role.id)
     end
   end
 
   describe "role_add_permission" do
     it "adds the permission to the role" do
-      role = Client.role_create(fake_endpoint, %{name: "role"}) |> get_value
-      permission = Client.permission_create(fake_endpoint, "permission") |> get_value
+      role = Client.role_create(valid_endpoint, %{name: "role"}) |> get_value
+      permission = Client.permission_create(valid_endpoint, "permission") |> get_value
       assert role.permissions == []
 
       permission_without_id = Map.delete permission, :id
-      role = Client.role_add_permission(fake_endpoint, role, permission_without_id) |> get_value
+      role = Client.role_add_permission(valid_endpoint, role, permission_without_id) |> get_value
 
       assert role.permissions == [permission]
     end
 
     context "when the permission cannot be added" do
       it "returns an :error" do
-        role = Client.role_create(fake_endpoint, %{name: "designer"}) |> get_value
+        role = Client.role_create(valid_endpoint, %{name: "designer"}) |> get_value
         permission = %Permission{name: "fake_permission", namespace: "s3"}
 
-        {:error, error} = Client.role_add_permission(fake_endpoint, role, permission)
+        {:error, error} = Client.role_add_permission(valid_endpoint, role, permission)
 
         assert error == ["Not found permissions - s3:fake_permission"]
       end
@@ -139,13 +139,13 @@ defmodule CogApi.Fake.RolesTest do
 
   describe "role_remove_permission" do
     it "removes the permission from the role" do
-      role = Client.role_create(fake_endpoint, %{name: "role"}) |> get_value
-      permission = Client.permission_create(fake_endpoint, "permission") |> get_value
-      role = Client.role_add_permission(fake_endpoint, role, permission) |> get_value
+      role = Client.role_create(valid_endpoint, %{name: "role"}) |> get_value
+      permission = Client.permission_create(valid_endpoint, "permission") |> get_value
+      role = Client.role_add_permission(valid_endpoint, role, permission) |> get_value
       assert role.permissions == [permission]
 
       permission_without_id = Map.delete permission, :id
-      role = Client.role_remove_permission(fake_endpoint, role, permission_without_id) |> get_value
+      role = Client.role_remove_permission(valid_endpoint, role, permission_without_id) |> get_value
 
       assert role.permissions == []
     end

--- a/test/unit/cog_api/fake/rules_test.exs
+++ b/test/unit/cog_api/fake/rules_test.exs
@@ -9,10 +9,10 @@ defmodule CogApi.Fake.RulesTest do
     it "returns a list of rules" do
       command_name = "operable:bundle"
       matching_rule_text = "when command is #{command_name}"
-      Client.rule_create(matching_rule_text, fake_endpoint)
-      Client.rule_create("when command is something:else", fake_endpoint)
+      Client.rule_create(matching_rule_text, valid_endpoint)
+      Client.rule_create("when command is something:else", valid_endpoint)
 
-      [rule] = Client.rule_index(command_name, fake_endpoint) |> get_value
+      [rule] = Client.rule_index(command_name, valid_endpoint) |> get_value
 
       assert present rule.id
       assert rule.rule == matching_rule_text
@@ -23,7 +23,7 @@ defmodule CogApi.Fake.RulesTest do
   describe "rule_create" do
     it "returns the created rule" do
       rule_text = "when command is operable:help must have operable:manage_commands"
-      rule = rule_text |> Client.rule_create(fake_endpoint) |> get_value
+      rule = rule_text |> Client.rule_create(valid_endpoint) |> get_value
 
       assert present rule.id
       assert rule.rule == rule_text
@@ -33,7 +33,7 @@ defmodule CogApi.Fake.RulesTest do
     context "when the rule is invalid" do
       it "returns the errors" do
         rule_text = "when command ERROR text operable:help"
-        {:error, [error]} = rule_text |> Client.rule_create(fake_endpoint)
+        {:error, [error]} = rule_text |> Client.rule_create(valid_endpoint)
 
         assert error =~ "Rule is invalid"
       end
@@ -43,16 +43,16 @@ defmodule CogApi.Fake.RulesTest do
   describe "rule_delete" do
     it "returns :ok" do
       rule_text = "when command is operable:which must have operable:manage_commands"
-      rule = rule_text |> Client.rule_create(fake_endpoint) |> get_value
+      rule = rule_text |> Client.rule_create(valid_endpoint) |> get_value
 
-      response = Client.rule_delete(rule.id, fake_endpoint)
+      response = Client.rule_delete(rule.id, valid_endpoint)
 
       assert response == :ok
     end
 
     context "when the rule cannot be deleted" do
       it "returns an error" do
-        {:error, [error]} = Client.rule_delete("NOT_REAL", fake_endpoint)
+        {:error, [error]} = Client.rule_delete("NOT_REAL", valid_endpoint)
 
         assert error == "Resource not found for: rules"
       end

--- a/test/unit/cog_api/fake/rules_test.exs
+++ b/test/unit/cog_api/fake/rules_test.exs
@@ -54,7 +54,7 @@ defmodule CogApi.Fake.RulesTest do
       it "returns an error" do
         {:error, [error]} = Client.rule_delete("NOT_REAL", fake_endpoint)
 
-        assert error == "The rule could not be deleted"
+        assert error == "Resource not found for: rules"
       end
     end
   end

--- a/test/unit/cog_api/fake/server_test.exs
+++ b/test/unit/cog_api/fake/server_test.exs
@@ -73,4 +73,20 @@ defmodule CogApi.Fake.ServerTest do
       assert group.relays == [relay.id]
     end
   end
+
+  describe "delete" do
+    it "returns :ok" do
+      relay = Server.create(Relay, %Relay{id: 1})
+
+      assert :ok == Server.delete(Relay, relay.id)
+    end
+
+    context "when the item does not exist" do
+      it "returns an error" do
+        {:error, [error]} = Server.delete(Relay, "1234")
+
+        assert error == "Resource not found for: relays"
+      end
+    end
+  end
 end

--- a/test/unit/cog_api/fake/triggers_test.exs
+++ b/test/unit/cog_api/fake/triggers_test.exs
@@ -13,7 +13,7 @@ defmodule CogApi.Fake.TriggersTest do
                  timeout_sec: 1,
                  description: "Echo!"}
 
-      {:ok, trigger} = Client.trigger_create(fake_endpoint, params)
+      {:ok, trigger} = Client.trigger_create(valid_endpoint, params)
 
       assert present(trigger.id)
       assert trigger.name == params.name
@@ -27,7 +27,7 @@ defmodule CogApi.Fake.TriggersTest do
     it "returns errors when invalid" do
       params = %{name: "ERROR"}
 
-      {:error, errors} = Client.trigger_create(fake_endpoint, params)
+      {:error, errors} = Client.trigger_create(valid_endpoint, params)
 
       assert errors == ["Name is invalid"]
     end
@@ -41,8 +41,8 @@ defmodule CogApi.Fake.TriggersTest do
                  timeout_sec: 60,
                  description: "Echoes stuff"}
 
-      {:ok, _}         = Client.trigger_create(fake_endpoint, params)
-      {:ok, [trigger]} = Client.trigger_index(fake_endpoint)
+      {:ok, _}         = Client.trigger_create(valid_endpoint, params)
+      {:ok, [trigger]} = Client.trigger_index(valid_endpoint)
 
       assert present(trigger.id)
       assert trigger.name == params.name
@@ -60,12 +60,12 @@ defmodule CogApi.Fake.TriggersTest do
                  timeout_sec: 60,
                  description: "Echoes stuff"}
 
-      {:ok, trigger}  = Client.trigger_create(fake_endpoint, params)
-      assert {:ok, ^trigger} = Client.trigger_show_by_name(fake_endpoint, params[:name])
+      {:ok, trigger}  = Client.trigger_create(valid_endpoint, params)
+      assert {:ok, ^trigger} = Client.trigger_show_by_name(valid_endpoint, params[:name])
     end
 
     it "returns nothing if searching by an invalid name" do
-      assert {:error, :not_found} = Client.trigger_show_by_name(fake_endpoint, "nothing_is_named_this")
+      assert {:error, :not_found} = Client.trigger_show_by_name(valid_endpoint, "nothing_is_named_this")
     end
   end
 
@@ -77,8 +77,8 @@ defmodule CogApi.Fake.TriggersTest do
                  timeout_sec: 42,
                  description: "Echoes more stuff"}
 
-      {:ok, created}   = Client.trigger_create(fake_endpoint, params)
-      {:ok, retrieved} = Client.trigger_show(fake_endpoint, created.id)
+      {:ok, created}   = Client.trigger_create(valid_endpoint, params)
+      {:ok, retrieved} = Client.trigger_show(valid_endpoint, created.id)
 
       assert retrieved.id == created.id
     end
@@ -92,10 +92,10 @@ defmodule CogApi.Fake.TriggersTest do
                           timeout_sec: 42,
                           description: "Echoes more stuff"}
 
-      {:ok, original} = Client.trigger_create(fake_endpoint, original_params)
+      {:ok, original} = Client.trigger_create(valid_endpoint, original_params)
 
       update_params = %{pipeline: "echo 'so much more stuff' > chat://#general"}
-      {:ok, updated} = Client.trigger_update(fake_endpoint, original.id, update_params)
+      {:ok, updated} = Client.trigger_update(valid_endpoint, original.id, update_params)
 
       assert updated.name == original.name
       assert updated.pipeline == update_params.pipeline
@@ -110,11 +110,11 @@ defmodule CogApi.Fake.TriggersTest do
                  timeout_sec: 100,
                  description: "Echoes all the things"}
 
-      {:ok, trigger} = Client.trigger_create(fake_endpoint, params)
+      {:ok, trigger} = Client.trigger_create(valid_endpoint, params)
 
-      assert :ok = Client.trigger_delete(fake_endpoint, trigger.id)
+      assert :ok = Client.trigger_delete(valid_endpoint, trigger.id)
 
-      {:ok, triggers} = Client.trigger_index(fake_endpoint)
+      {:ok, triggers} = Client.trigger_index(valid_endpoint)
       refute Enum.member?(triggers, trigger)
     end
   end

--- a/test/unit/cog_api/fake/users_test.exs
+++ b/test/unit/cog_api/fake/users_test.exs
@@ -14,9 +14,9 @@ defmodule CogApi.Fake.UsersTest do
         username: "chief_of_staff",
         password: "supersecret",
       }
-      {:ok, _} = Client.user_create(fake_endpoint, params)
+      {:ok, _} = Client.user_create(valid_endpoint, params)
 
-      users = Client.user_index(fake_endpoint) |> get_value
+      users = Client.user_index(valid_endpoint) |> get_value
 
       last_user = List.last users
       assert present last_user.id
@@ -36,13 +36,13 @@ defmodule CogApi.Fake.UsersTest do
         username: "aide_to_potus",
         password: "thesecretest",
       }
-      created_user = Client.user_create(fake_endpoint, params) |> get_value
-      role = Client.role_create(fake_endpoint, %{name: "user_show_role"}) |> get_value
-      group = Client.group_create(fake_endpoint, %{name: "user_show_group"}) |> get_value
-      Client.group_add_role(fake_endpoint, group, role)
-      Client.group_add_user(fake_endpoint, group, created_user)
+      created_user = Client.user_create(valid_endpoint, params) |> get_value
+      role = Client.role_create(valid_endpoint, %{name: "user_show_role"}) |> get_value
+      group = Client.group_create(valid_endpoint, %{name: "user_show_group"}) |> get_value
+      Client.group_add_role(valid_endpoint, group, role)
+      Client.group_add_user(valid_endpoint, group, created_user)
 
-      found_user = Client.user_show(fake_endpoint, created_user.id) |> get_value
+      found_user = Client.user_show(valid_endpoint, created_user.id) |> get_value
 
       assert found_user.id == created_user.id
       assert Enum.map(found_user.groups, &(&1.id)) == [group.id]
@@ -57,14 +57,14 @@ defmodule CogApi.Fake.UsersTest do
         username: "aide_to_snoopy",
         password: "kicktheball",
       }
-      created_user = Client.user_create(fake_endpoint, params) |> get_value
-      role = Client.role_create(fake_endpoint, %{name: "dancer"}) |> get_value
-      group = Client.group_create(fake_endpoint, %{name: "peanuts"}) |> get_value
-      Client.group_add_role(fake_endpoint, group, role)
-      Client.group_add_user(fake_endpoint, group, created_user)
+      created_user = Client.user_create(valid_endpoint, params) |> get_value
+      role = Client.role_create(valid_endpoint, %{name: "dancer"}) |> get_value
+      group = Client.group_create(valid_endpoint, %{name: "peanuts"}) |> get_value
+      Client.group_add_role(valid_endpoint, group, role)
+      Client.group_add_user(valid_endpoint, group, created_user)
 
       found_user = Client.user_show(
-        fake_endpoint,
+        valid_endpoint,
         %{username: created_user.username}
       ) |> get_value
 
@@ -84,7 +84,7 @@ defmodule CogApi.Fake.UsersTest do
         username: "chief_of_staff",
         password: "supersecret",
       }
-      user = Client.user_create(fake_endpoint, params) |> get_value
+      user = Client.user_create(valid_endpoint, params) |> get_value
 
       assert present user.id
       assert user.first_name == params.first_name
@@ -97,7 +97,7 @@ defmodule CogApi.Fake.UsersTest do
       params = %{
         username: "ERROR",
       }
-      {:error, errors} = Client.user_create(fake_endpoint, params)
+      {:error, errors} = Client.user_create(valid_endpoint, params)
 
       assert errors == ["Username is invalid"]
     end
@@ -112,10 +112,10 @@ defmodule CogApi.Fake.UsersTest do
         username: "arnie",
         password: "12345",
       }
-      new_user = Client.user_create(fake_endpoint, original_params) |> get_value
+      new_user = Client.user_create(valid_endpoint, original_params) |> get_value
 
       update_params = %{first_name: "Arnie"}
-      updated_user = Client.user_update(fake_endpoint, new_user.id, update_params) |> get_value
+      updated_user = Client.user_update(valid_endpoint, new_user.id, update_params) |> get_value
 
       assert updated_user.first_name == update_params.first_name
       assert updated_user.last_name == original_params.last_name
@@ -131,11 +131,11 @@ defmodule CogApi.Fake.UsersTest do
         username: "chief_of_staff",
         password: "supersecret",
       }
-      user = Client.user_create(fake_endpoint, params) |> get_value
+      user = Client.user_create(valid_endpoint, params) |> get_value
 
-      response = Client.user_delete(fake_endpoint, user.id)
+      response = Client.user_delete(valid_endpoint, user.id)
 
-      users = Client.user_index(fake_endpoint) |> get_value
+      users = Client.user_index(valid_endpoint) |> get_value
 
       assert response == :ok
       refute Enum.member?(users, user)


### PR DESCRIPTION
* Add a check for existence to the server delete function. This something that all resources should be doing anyway so we may as well move that to the server. This simplifies the implement of most delete functions
* Extract a function for returning an error. This isn't that complicated but it's nice to have the solution in one place.
* Rename `fake_endpoint` to `valid_endpoint`. This makes it easier to reproduce the HTTP tests in the Fake cases.