### PR TITLE
Send back authentication errors from Cog

### DIFF
--- a/lib/cog_api/fake/bundles.ex
+++ b/lib/cog_api/fake/bundles.ex
@@ -9,13 +9,12 @@ defmodule CogApi.Fake.Bundles do
   alias CogApi.Resources.Command
 
   import CogApi.Decoders.Bundle, only: [modifiable?: 1]
+  use CogApi.Fake.InvalidCrudResponses
 
-  def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
     {:ok, Server.index(Bundle)}
   end
 
-  def show(%Endpoint{token: nil}, _),  do: Endpoint.invalid_endpoint
   def show(%Endpoint{}=endpoint, id) do
     bundle = Server.show!(Bundle, id)
     bundle = %{bundle | commands: add_rules(endpoint, bundle)}
@@ -35,7 +34,6 @@ defmodule CogApi.Fake.Bundles do
     rules
   end
 
-  def create(%Endpoint{token: nil}, %{name: _}), do: Endpoint.invalid_endpoint
   def create(endpoint=%Endpoint{token: _}, params) do
     params = to_atom_keys(params)
     catch_errors %Bundle{}, params, fn ->
@@ -75,7 +73,6 @@ defmodule CogApi.Fake.Bundles do
     return_error("You can only enable or disable a bundle")
   end
 
-  def delete(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id), do: Server.delete(Bundle, id)
 
   defp ensure_bundle_encode_status(status) do

--- a/lib/cog_api/fake/chat_handles.ex
+++ b/lib/cog_api/fake/chat_handles.ex
@@ -6,7 +6,8 @@ defmodule CogApi.Fake.ChatHandles do
   alias CogApi.Fake.Server
   alias CogApi.Resources.ChatHandle
 
-  def create(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
+  use CogApi.Fake.InvalidCrudResponses
+
   def create(%Endpoint{token: _}, user_id, params) do
     catch_errors %ChatHandle{}, params, fn ->
       new_chat_handle = %ChatHandle{id: random_string(8), user_id: user_id}
@@ -15,14 +16,12 @@ defmodule CogApi.Fake.ChatHandles do
     end
   end
 
-  def update(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def update(%Endpoint{token: _}, id, params) do
     catch_errors %ChatHandle{}, params, fn ->
       {:ok, Server.update(ChatHandle, id, params)}
     end
   end
 
-  def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id), do: Server.delete(ChatHandle, id)
 
   def for_user(_, %Endpoint{token: nil}), do: Endpoint.invalid_endpoint

--- a/lib/cog_api/fake/groups.ex
+++ b/lib/cog_api/fake/groups.ex
@@ -9,13 +9,12 @@ defmodule CogApi.Fake.Groups do
   alias CogApi.Resources.User
 
   import CogApi.Decoders.Group, only: [modifiable?: 1]
+  use CogApi.Fake.InvalidCrudResponses
 
-  def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
   def index(%Endpoint{}) do
     {:ok, Server.index(Group)}
   end
 
-  def show(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def show(%Endpoint{token: _}, id) do
     Server.show(Group, id)
   end
@@ -31,7 +30,6 @@ defmodule CogApi.Fake.Groups do
     end
   end
 
-  def create(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def create(%Endpoint{token: _}, %{name: name}=params) do
     catch_errors %Group{}, params, fn ->
       new_group = %Group{
@@ -43,14 +41,12 @@ defmodule CogApi.Fake.Groups do
     end
   end
 
-  def update(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def update(%Endpoint{token: _}, id, %{name: _name}=params) do
     catch_errors %Group{}, params, fn ->
       {:ok, Server.update(Group, id, params)}
     end
   end
 
-  def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id), do: Server.delete(Group, id)
 
   def add_role(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint

--- a/lib/cog_api/fake/invalid_crud_responses.ex
+++ b/lib/cog_api/fake/invalid_crud_responses.ex
@@ -1,0 +1,47 @@
+defmodule CogApi.Fake.InvalidCrudResponses do
+  defmacro __using__(_opts) do
+    quote do
+      alias CogApi.Endpoint
+      @invalid_token "INVALID"
+
+      def index(%Endpoint{token: nil}) do
+        Endpoint.invalid_endpoint
+      end
+      def index(%Endpoint{token: @invalid_token}) do
+        invalid_token
+      end
+
+      def show(%Endpoint{token: nil}, _) do
+        Endpoint.invalid_endpoint
+      end
+      def show(%Endpoint{token: @invalid_token}, _) do
+        invalid_token
+      end
+
+      def create(%Endpoint{token: nil}, _) do
+        Endpoint.invalid_endpoint
+      end
+      def create(%Endpoint{token: @invalid_token}, _) do
+        invalid_token
+      end
+
+      def update(%Endpoint{token: nil}, _, _) do
+        Endpoint.invalid_endpoint
+      end
+      def update(%Endpoint{token: @invalid_token}, _, _) do
+        invalid_token
+      end
+
+      def delete(%Endpoint{token: nil}, _) do
+        Endpoint.invalid_endpoint
+      end
+      def delete(%Endpoint{token: @invalid_token}, _) do
+        invalid_token
+      end
+
+      defp invalid_token do
+        {:authentication_error, ["User cannot be authenticated"]}
+      end
+    end
+  end
+end

--- a/lib/cog_api/fake/permissions.ex
+++ b/lib/cog_api/fake/permissions.ex
@@ -6,12 +6,12 @@ defmodule CogApi.Fake.Permissions do
   alias CogApi.Fake.Server
   alias CogApi.Resources.Permission
 
-  def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
+  use CogApi.Fake.InvalidCrudResponses
+
   def index(%Endpoint{}) do
     {:ok, Server.index(Permission)}
   end
 
-  def create(%Endpoint{token: nil}, %{name: _}), do: Endpoint.invalid_endpoint
   def create(%Endpoint{token: _}, name) do
     catch_errors %Permission{}, %{name: name}, fn ->
       [namespace, name] = build_namespaced_name(name)
@@ -26,7 +26,6 @@ defmodule CogApi.Fake.Permissions do
     end
   end
 
-  def delete(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id) do
     if permission = Server.show!(Permission, id) do
       if permission.namespace == "site" do

--- a/lib/cog_api/fake/roles.ex
+++ b/lib/cog_api/fake/roles.ex
@@ -8,12 +8,12 @@ defmodule CogApi.Fake.Roles do
   alias CogApi.Resources.Permission
   alias CogApi.Resources.Role
 
-  def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
+  use CogApi.Fake.InvalidCrudResponses
+
   def index(%Endpoint{}) do
     {:ok, Server.index(Role) |> Enum.map(&(prepare_role(&1)))}
   end
 
-  def show(%Endpoint{token: nil}, _),  do: Endpoint.invalid_endpoint
   def show(%Endpoint{}, %{name: name}) do
     {:ok, prepare_role(Server.show_by_key(Role, :name, name))}
   end
@@ -21,7 +21,6 @@ defmodule CogApi.Fake.Roles do
     {:ok, prepare_role(Server.show!(Role, id))}
   end
 
-  def create(%Endpoint{token: nil}, %{name: _}), do: Endpoint.invalid_endpoint
   def create(%Endpoint{token: _}, %{name: name}=params) do
     catch_errors %Role{}, params, fn ->
       new_role = %Role{id: random_string(8), name: name}
@@ -29,14 +28,12 @@ defmodule CogApi.Fake.Roles do
     end
   end
 
-  def update(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def update(%Endpoint{token: _}, id, params) do
     catch_errors %Role{}, params, fn ->
       {:ok, Server.update(Role, id, params) |> prepare_role}
     end
   end
 
-  def delete(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def delete(%Endpoint{token: _}, id), do: Server.delete(Role, id)
 
   def add_permission(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint

--- a/lib/cog_api/fake/triggers.ex
+++ b/lib/cog_api/fake/triggers.ex
@@ -6,6 +6,8 @@ defmodule CogApi.Fake.Triggers do
   alias CogApi.Fake.Server
   alias CogApi.Resources.Trigger
 
+  use CogApi.Fake.InvalidCrudResponses
+
   def by_name(%Endpoint{token: nil}),
     do: Endpoint.invalid_endpoint
   def by_name(%Endpoint{}, name) do
@@ -17,14 +19,10 @@ defmodule CogApi.Fake.Triggers do
     end
   end
 
-  def index(%Endpoint{token: nil}), do: Endpoint.invalid_endpoint
   def index(%Endpoint{}), do: {:ok, Server.index(Trigger)}
 
-  def show(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def show(%Endpoint{}, id), do: Server.show(Trigger, id)
 
-  def create(%Endpoint{token: nil}, _),
-    do: Endpoint.invalid_endpoint
   def create(%Endpoint{token: _}, params) do
     catch_errors %Trigger{}, params, fn ->
       id = random_string(8)
@@ -38,8 +36,6 @@ defmodule CogApi.Fake.Triggers do
     end
   end
 
-  def update(%Endpoint{token: nil}, _, _),
-    do: Endpoint.invalid_endpoint
   def update(%Endpoint{token: _}, id, params) do
     catch_errors %Trigger{}, params, fn ->
       {:ok, Server.update(Trigger, id, params)}

--- a/lib/cog_api/fake/users.ex
+++ b/lib/cog_api/fake/users.ex
@@ -6,12 +6,12 @@ defmodule CogApi.Fake.Users do
   alias CogApi.Fake.Server
   alias CogApi.Resources.User
 
-  def index(%Endpoint{token: nil}),  do: Endpoint.invalid_endpoint
+  use CogApi.Fake.InvalidCrudResponses
+
   def index(%Endpoint{}) do
     {:ok, Server.index(User)}
   end
 
-  def show(%Endpoint{token: nil}, _),  do: Endpoint.invalid_endpoint
   def show(%Endpoint{}, %{username: username}) do
     {:ok, Server.show_by_key(User, :username, username)}
   end
@@ -19,7 +19,6 @@ defmodule CogApi.Fake.Users do
     Server.show(User, id)
   end
 
-  def create(%Endpoint{token: nil}, _), do: Endpoint.invalid_endpoint
   def create(%Endpoint{token: _}, params) do
     catch_errors %User{}, params, fn ->
       new_user = %User{id: random_string(8)}
@@ -28,7 +27,6 @@ defmodule CogApi.Fake.Users do
     end
   end
 
-  def update(%Endpoint{token: nil}, _, _), do: Endpoint.invalid_endpoint
   def update(%Endpoint{token: _}, id, params) do
     catch_errors %User{}, params, fn ->
       {:ok, Server.update(User, id, params)}

--- a/test/unit/cog_api/fake/bundles_test.exs
+++ b/test/unit/cog_api/fake/bundles_test.exs
@@ -16,6 +16,13 @@ defmodule CogApi.Fake.BundlesTest do
       assert error_message == "You must provide an authenticated endpoint"
     end
 
+    it "returns an authentication error with an invalid token" do
+      {response, [error_message]} = Client.bundle_index(%Endpoint{token: "INVALID"})
+
+      assert response == :authentication_error
+      assert error_message == "User cannot be authenticated"
+    end
+
     it "returns a list of bundles" do
       bundle = %Bundle{id: "id123", name: "bundle"}
       Server.create(Bundle, bundle)

--- a/test/unit/cog_api/http/api_response_test.exs
+++ b/test/unit/cog_api/http/api_response_test.exs
@@ -16,9 +16,21 @@ defmodule CogApi.HTTP.ApiResponseTest do
     end
 
     for code <- 400..500 do
-      it "returns an error for a #{code}" do
-        http_response = %Response{status_code: unquote(code), body: Poison.encode!(%{error: "oops"})}
-        assert {:error, ["oops"]} == ApiResponse.format(http_response)
+      if code == 401 do
+        it "returns an authentication error for 401" do
+          http_response = %Response{
+            status_code: 401,
+            body: Poison.encode!(%{error: "User cannot be authenticated"}),
+          }
+
+          expected_error = {:authentication_error, ["User cannot be authenticated"]}
+          assert expected_error == ApiResponse.format(http_response)
+        end
+      else
+        it "returns an error for a #{code}" do
+          http_response = %Response{status_code: unquote(code), body: Poison.encode!(%{error: "oops"})}
+          assert {:error, ["oops"]} == ApiResponse.format(http_response)
+        end
       end
     end
   end


### PR DESCRIPTION
If a 401 response comes back from cog, this will now respond with `{:authentication_error, [errors]}`, so that API consumers can more easily pattern match for that error type.

This also extracts a module to make it easier to implement that functionality in the fake server.