### PR TITLE
optional status code return

### DIFF
--- a/lib/cog_api/http/internal.ex
+++ b/lib/cog_api/http/internal.ex
@@ -1,6 +1,14 @@
 defmodule CogApi.HTTP.Internal do
   alias CogApi.Endpoint
 
+  @doc """
+  Makes a GET request to the cog api
+
+  Returns a tuple containing the status, ':ok | :error', of the response and
+  the parsed response body. Takes '{status_code: true}' as an option and
+  returns the HTTP status code instead of a status atom.
+  """
+  @spec get(%Endpoint{}, String.t, Map.t, Keyword.t) :: {:ok | :error, any()} | {integer(), any()}
   def get(%Endpoint{}=endpoint, resource, params \\ %{}, opts \\ []) do
     rescue_econnrefused(fn ->
       HTTPotion.get(make_url(endpoint, resource, params), headers: make_headers(endpoint))
@@ -8,6 +16,14 @@ defmodule CogApi.HTTP.Internal do
     end)
   end
 
+  @doc """
+  Makes a POST request to the cog api
+
+  Returns a tuple containing the status, ':ok | :error', of the response and
+  the parsed response body. Takes '{status_code: true}' as an option and
+  returns the HTTP status code instead of a status atom.
+  """
+  @spec post(%Endpoint{}, String.t, Map.t, Keyword.t) :: {:ok | :error, any()} | {integer(), any()}
   def post(%Endpoint{}=endpoint, resource, params, opts \\ []) do
     rescue_econnrefused(fn ->
       body = Poison.encode!(params)
@@ -16,6 +32,14 @@ defmodule CogApi.HTTP.Internal do
     end)
   end
 
+  @doc """
+  Makes a PATCH request to the cog api
+
+  Returns a tuple containing the status, ':ok | :error', of the response and
+  the parsed response body. Takes '{status_code: true}' as an option and
+  returns the HTTP status code instead of a status atom.
+  """
+  @spec patch(%Endpoint{}, String.t, Map.t, Keyword.t) :: {:ok | :error, any()} | {integer(), any()}
   def patch(%Endpoint{}=endpoint, resource, params, opts \\ []) do
     rescue_econnrefused(fn ->
       body = Poison.encode!(params)
@@ -24,6 +48,14 @@ defmodule CogApi.HTTP.Internal do
     end)
   end
 
+  @doc """
+  Makes a DELETE request to the cog api
+
+  Returns a tuple containing the status, ':ok | :error', of the response and
+  the parsed response body. Takes '{status_code: true}' as an option and
+  returns the HTTP status code instead of a status atom.
+  """
+  @spec delete(%Endpoint{}, String.t, Keyword.t) :: :ok | {:error, any()} | {integer(), any()}
   def delete(%Endpoint{}=endpoint, resource, opts \\ []) do
     rescue_econnrefused(fn ->
       response = HTTPotion.delete(make_url(endpoint, resource), headers: make_headers(endpoint))
@@ -77,8 +109,13 @@ defmodule CogApi.HTTP.Internal do
     get(endpoint, "bootstrap")
   end
 
+  @doc """
+  Bootstraps Cog. Returns the admin creds if the instance has not been
+  bootstrapped. Returns an error otherwise.
+  """
+  @spec bootstrap_create(%Endpoint{}, Keyword.t) :: {:ok | :error, any()} | {integer(), any()}
   def bootstrap_create(%Endpoint{}=endpoint, opts \\ []) do
-    post(endpoint, "bootstrap", [], opts)
+    post(endpoint, "bootstrap", %{}, opts)
   end
 
   def bundle_show(%Endpoint{}=endpoint, bundle_name) do


### PR DESCRIPTION
This adds an optional flag for returning the http status code of the response instead of an `:ok | :error` atom in 'CogApi.HTTP.Internal`. The only function that utilizes it currently is 'bootstrap_create', since that's the one I needed it for.

I also added some specs and docs to the functions that I updated.