### PR TITLE
return an error when the api returns an error

### DIFF
--- a/lib/cog_api/http/groups.ex
+++ b/lib/cog_api/http/groups.ex
@@ -51,11 +51,12 @@ defmodule CogApi.HTTP.Groups do
   end
 
   defp format_response(response, group) do
-    roles = ApiResponse.parse_struct(response,  %{"roles" => [Role.format]})
-    {
-      ApiResponse.type(response),
-      %{group | roles: roles}
-    }
+    case ApiResponse.format(response, %{"roles" => [Role.format]}) do
+      {:error, error} ->
+        {:error, error}
+      {code, roles} ->
+        {code, %{group | roles: roles}}
+    end
   end
 
   def add_user(%Endpoint{}=endpoint, group, user) do

--- a/mix.lock
+++ b/mix.lock
@@ -7,6 +7,6 @@
   "httpotion": {:hex, :httpotion, "3.0.1", "6165e7fe4052dfeadd4b480e4ed6619975242ac91d577e4868af92613f9e99df", [:mix], [{:ibrowse, "~> 4.2", [hex: :ibrowse, optional: false]}]},
   "ibrowse": {:hex, :ibrowse, "4.2.2", "b32b5bafcc77b7277eff030ed32e1acc3f610c64e9f6aea19822abcadf681b4b", [:rebar3], []},
   "jsx": {:hex, :jsx, "2.6.2", "213721e058da0587a4bce3cc8a00ff6684ced229c8f9223245c6ff2c88fbaa5a", [:mix, :rebar], []},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},
+  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []}}


### PR DESCRIPTION
This updates role grant/revoke in groups to return an error when the api returns an error.

part of https://github.com/operable/cog/issues/825
and https://github.com/operable/cog/pull/1180